### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,9 @@
 
 name: Lint and Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/whyisdifficult/jiratui/security/code-scanning/1](https://github.com/whyisdifficult/jiratui/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block to limit the access level of the default `GITHUB_TOKEN`. Since the workflow only requires code checkout, dependency management, testing, and artifact upload, the minimal required permission is `contents: read`. This can be set either at the root (applies to all jobs) or at the job level (`lint-and-test`). The recommended approach is to add a top-level (root) `permissions` block just after `name:` and `on:` in `.github/workflows/test.yaml`. No new methods or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
