### PR TITLE
Update installation command for jiratui

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A **Text User Interface (TUI)** for interacting with Atlassian Jira directly fro
 The recommended way to install the application is via [uv](https://docs.astral.sh/uv/):
 
 ```shell
-uv add jiratui
+uv tool install jiratui
 ```
 
 Alternatively, you can install it using `pip`:


### PR DESCRIPTION
You probably want to use `uv tool install jiratui`, as that'll set up the program globally. `uv add jiratui` will add it into whatever project someone happens to be in