### PR TITLE
Fix installation instructions

### DIFF
--- a/docs/users/install/index.md
+++ b/docs/users/install/index.md
@@ -3,7 +3,7 @@
 The recommended way to install the application is via [uv](https://docs.astral.sh/uv/):
 
 ```shell
-uv add jiratui
+uv tool install jiratui
 ```
 
 Alternatively, you can install it using `pip`:


### PR DESCRIPTION
`uv add` adds a dependency to a Python project. You want `uv tool install` which installs a tool.