### PR TITLE
Add support for displaying custom fields in the information tab of a...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-09-13
+
+### Added
+
+- Display (optional) custom fields of type text/textarea in the Info tab pane of an issue. Only custom fields that can
+be edited will be displayed.
+- Rename `Description` tab to `Info`.
+- Add support for additional [ADF](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/) node types
+- Add more tests
+- Show a warning in the comments of an issue when the content of the comment can not be displayed
+- Add a SECURITY file with the security policy by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/11
+
+### Changes
+
+#### Application
+
+- Remove dependency on [tonalite](https://github.com/Tiqets/tonalite) because it is not needed.
+- Move `pre-commit` dependency to the `dev` group
+- Update tests to use a mock config file
+- Update `rtd` dependencies to use [sphinx-design](https://sphinx-design.readthedocs.io/en/latest/) by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/10
+- Update installation command for jiratui by [@rtpg](https://github.com/rtpg) in https://github.com/whyisdifficult/jiratui/pull/25
+
+#### Project
+
+- Update issue templates by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/12
+- Add template for requesting new features by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/13
+- Update issue templates with a template for bug report by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/14
+- Separate lint and tests jobs by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/16
+
+### New Contributors
+- [@rtpg](https://github.com/rtpg) made their first contribution in https://github.com/whyisdifficult/jiratui/pull/25
+
 ## [0.1.1] - 2025-09-06
 
 ### Added

--- a/docs/users/install/index.md
+++ b/docs/users/install/index.md
@@ -3,7 +3,7 @@
 The recommended way to install the application is via [uv](https://docs.astral.sh/uv/):
 
 ```shell
-uv add jiratui
+uv tool install jiratui
 ```
 
 Alternatively, you can install it using `pip`:

--- a/jtsite/getting-started.html
+++ b/jtsite/getting-started.html
@@ -141,7 +141,7 @@
 
                         <p>The recommended way to install the application is via <a href="https://docs.astral.sh/uv/" target="_blank">uv</a></p>
                         <div class="position-relative border rounded-1 border-700 p-1">
-                          <pre><code id="codeBlock1">uv add jiratui</code></pre>
+                          <pre><code id="codeBlock1">uv tool install jiratui</code></pre>
                           <button class="btn btn-sm btn-outline-secondary copy-btn" id="copyButton1" onclick="copyCode('codeBlock1', 'copyButton1')">
                             <i class="bi bi-clipboard"></i> Copy
                           </button>

--- a/jtsite/getting-started.html
+++ b/jtsite/getting-started.html
@@ -209,7 +209,7 @@ Commands:
 
                         <ul>
                           <li><code class="fs-0">jira_api_username</code> - the username for connecting to your Jira's API.</li>
-                          <li><code class="fs-0">jira_api_token</code> - the token for connecting to your Jira's API.</li>
+                          <li><code class="fs-0">jira_api_token</code> - the token for connecting to your Jira's API. This can be a Personal Access Token (PAT)</li>
                           <li><code class="fs-0">jira_api_base_url</code> - the base URL of your Jira instance API.</li>
                         </ul>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jiratui"
-version = "0.1.1"
+version = "0.2.0"
 description = "A TUI for interacting with Atlassian Jira from your terminal."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,9 @@ classifiers = [
 dependencies = [
     "click>=8.2.1",
     "httpx>=0.28.1",
-    "pre-commit>=4.3.0",
     "pydantic-settings[yaml]>=2.10.1",
     "python-json-logger>=3.3.0",
     "textual[syntax]>=5.3.0",
-    "tonalite>=1.8.4",
 ]
 
 [project.urls]
@@ -48,6 +46,7 @@ Changelog = "https://github.com/whyisdifficult/jiratui/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [
+    "pre-commit>=4.3.0",
     "textual-dev>=1.7.0",
 ]
 docs = [

--- a/src/jiratui/api_controller/factories.py
+++ b/src/jiratui/api_controller/factories.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import json
+from typing import Any
 
 from jiratui.config import CONFIGURATION
 from jiratui.models import (
@@ -30,6 +31,7 @@ def build_issue_instance(
     parent_issue_key: str | None = None,
     priority: dict | None = None,
     edit_meta: dict | None = None,
+    editable_custom_fields: dict[str, Any] | None = None,
 ) -> JiraIssue:
     """Builds an instance of `JiraIssue` with the details of a work item.
 
@@ -46,6 +48,8 @@ def build_issue_instance(
         parent_issue_key: the case-sensitive key of the parent issue.
         priority: a dictionary with the details of the item's priority.
         edit_meta: a dictionary with the details of the item's metadata for editing the item.
+        editable_custom_fields: a dictionary with the value of the custom fields associated to the issue that support
+        editing.
 
     Returns:
         An instance of `JiraIssue`.
@@ -151,6 +155,7 @@ def build_issue_instance(
         due_date=datetime.strptime(fields.get('duedate'), '%Y-%m-%d').date()
         if fields.get('duedate')
         else None,
+        editable_custom_fields=editable_custom_fields,
     )
 
 

--- a/src/jiratui/api_controller/tests/test_controller.py
+++ b/src/jiratui/api_controller/tests/test_controller.py
@@ -949,6 +949,8 @@ def test_build_criteria_for_searching_work_items(
     expected_criteria,
     jira_api_controller: APIController,
 ):
+    # GIVEN
+    jira_api_controller.config.jql_expression_id_for_work_items_search = None
     # WHEN
     criteria = jira_api_controller._build_criteria_for_searching_work_items(
         project_key=project_key,

--- a/src/jiratui/css/jt.tcss
+++ b/src/jiratui/css/jt.tcss
@@ -163,7 +163,8 @@ IssueCommentsWidget {
 /* Tab Pane - Description */
 
 .summary-description-container {
-    border: solid $primary;
+    height: 100;
+    margin: 0 0;
 }
 
 /* margin: top right bottom left*/
@@ -173,6 +174,7 @@ IssueCommentsWidget {
 
 IssueDescriptionWidget {
     background: transparent;
+    margin: 0 0;
 }
 
 /*  Work Item Details */
@@ -812,4 +814,41 @@ JQLEditorScreen > Vertical {
     &:focus {
         border: round $accent-lighten-3;
     }
+}
+
+/* Work Item Information (description, summary and custom fields) */
+
+#work-item-info-description-scroll-container {
+    border: solid $secondary-lighten-3;
+    padding: 0 0 0 0;
+    scrollbar-size-vertical: 1;
+}
+
+#work-item-info-extra-scroll-container {
+    border: solid $secondary;
+    scrollbar-size-vertical: 1;
+}
+
+.summary-description-container {
+    height: auto;
+    margin: 0 0;
+    padding: 0 0;
+}
+
+.work-item-info-custom-field-textarea {
+    border-top: solid $secondary-lighten-3;
+    margin: 0 0;
+    padding: 0 0;
+}
+
+MarkdownFence {
+    background: $surface;
+}
+
+WorkItemSummaryContainer {
+    border-left: solid $secondary-lighten-3;
+    height: auto;
+    margin-bottom: 1;
+    color: $text;
+    text-style: italic;
 }

--- a/src/jiratui/widgets/comments/comments.py
+++ b/src/jiratui/widgets/comments/comments.py
@@ -159,9 +159,15 @@ pressing `d`. Comments can be added by pressing `n`.
         items.sort(key=lambda x: x.updated, reverse=True)
         for comment in items:
             try:
-                comment_text = adf2md(comment.body_as_dict())
+                content = adf2md(comment.body_as_dict())
+                comment_text = Markdown(content)
             except Exception:
-                comment_text = 'Unable to display the comment. Open the link above to view it.'
+                comment_text = Static(
+                    Text(
+                        'Unable to display the comment. Open the link above to view it.',
+                        style='bold orange',
+                    )
+                )
 
             url = (
                 build_external_url_for_comment(self.issue_key, comment.id) if self.issue_key else ''
@@ -172,7 +178,7 @@ pressing `d`. Comments can be added by pressing `n`.
                     Link('Open link', url=url, tooltip='view comment in the browser'),
                     Static(f'Last update: {comment.updated_on()}'),
                     Rule(),
-                    Markdown(comment_text),
+                    comment_text,
                     title=Text(comment.short_metadata()),
                     work_item_key=self.issue_key,
                     comment_id=comment.id,

--- a/src/jiratui/widgets/comments/comments.py
+++ b/src/jiratui/widgets/comments/comments.py
@@ -157,6 +157,7 @@ pressing `d`. Comments can be added by pressing `n`.
         comment: IssueComment
         elements: list[CommentCollapsible] = []
         items.sort(key=lambda x: x.updated, reverse=True)
+        comment_text: Markdown | Static
         for comment in items:
             try:
                 content = adf2md(comment.body_as_dict())

--- a/src/jiratui/widgets/screens.py
+++ b/src/jiratui/widgets/screens.py
@@ -600,7 +600,7 @@ class MainScreen(Screen):
                 severity='warning',
                 title='Work Item Search',
             )
-            WorkItemSearchResult(total=0, start=0, end=0)
+            return WorkItemSearchResult(total=0, start=0, end=0)
 
         result: JiraIssueSearchResponse = response.result
         estimated_total_issues: int | None = None

--- a/src/jiratui/widgets/work_item_info/info.py
+++ b/src/jiratui/widgets/work_item_info/info.py
@@ -1,0 +1,141 @@
+from textual.app import ComposeResult
+from textual.containers import Container, VerticalGroup, VerticalScroll
+from textual.reactive import Reactive, reactive
+from textual.widgets import Markdown
+
+from jiratui.models import CustomFieldTypes, JiraIssue
+from jiratui.utils.adf2md.adf2md import adf2md
+from jiratui.widgets.summary import IssueDescriptionWidget, IssueSummaryWidget
+
+
+class WorkItemSummaryContainer(Container):
+    """The container that holds the read-only summary of the work item."""
+
+    def __init__(self):
+        super().__init__()
+        self.visible = False
+
+
+class WorkItemInfoContainer(VerticalGroup):
+    issue: Reactive[JiraIssue | None] = reactive(None, always_update=True)
+    """The issue whose information we want to display."""
+    clear_information: Reactive[bool] = reactive(False, always_update=True)
+    """Reactive variable to clear the summary, description and extra fields."""
+
+    def __init__(self):
+        super().__init__(id='work_item_info_container')
+        self._has_extra_custom_fields = False
+
+    @property
+    def issue_summary_widget(self) -> IssueSummaryWidget:
+        return self.query_one(IssueSummaryWidget)
+
+    @property
+    def issue_description_widget(self) -> IssueDescriptionWidget:
+        return self.query_one(IssueDescriptionWidget)
+
+    @property
+    def summary_container_widget(self) -> WorkItemSummaryContainer:
+        return self.query_one(WorkItemSummaryContainer)
+
+    @property
+    def extra_fields_container(self) -> VerticalScroll:
+        return self.query_one('#work-item-info-extra-scroll-container', expect_type=VerticalScroll)
+
+    @property
+    def description_container(self) -> VerticalScroll:
+        return self.query_one(
+            '#work-item-info-description-scroll-container', expect_type=VerticalScroll
+        )
+
+    def compose(self) -> ComposeResult:
+        with VerticalGroup():
+            with WorkItemSummaryContainer():
+                yield IssueSummaryWidget()
+            with VerticalScroll(id='work-item-info-description-scroll-container'):
+                yield IssueDescriptionWidget()
+            yield VerticalScroll(id='work-item-info-extra-scroll-container')
+
+    async def _setup_work_item_description(self, description: dict | list) -> None:
+        if description:
+            if content := self._extract_adf(description):
+                await self.issue_description_widget.update(content.strip())
+            else:
+                await self.issue_description_widget.update('Unable to display the description.')
+            self.issue_description_widget.visible = True
+            self.description_container.visible = True
+            self.description_container.border_title = 'Description'
+        else:
+            self.description_container.visible = False
+            self.issue_description_widget.visible = False
+            await self.issue_description_widget.update('')
+
+    def watch_issue(self, work_item: JiraIssue | None) -> None:
+        # "reset" the information of any previous widget
+        self.clear_information = True
+
+        if not work_item:
+            return None
+
+        # set the summary of the work item and make the widget visible
+        self.issue_summary_widget.update(work_item.summary)
+        self.issue_summary_widget.visible = True
+        self.summary_container_widget.visible = True
+
+        # set the description of the work item and make the widget visible
+        self.run_worker(self._setup_work_item_description(work_item.description))
+
+        # display all the editable custom fields with whose type is string-textarea
+        self._has_extra_custom_fields = False
+        if issue_edit_metadata := work_item.get_edit_metadata():
+            for field_key, field_data in issue_edit_metadata.items():
+                if field_data.get('key', '').startswith('customfield_') or field_key.startswith(
+                    'customfield_'
+                ):
+                    if field_schema := field_data.get('schema'):
+                        schema_custom = field_schema.get('custom')
+                        schema_type = field_schema.get('type')
+                        if (
+                            schema_type == 'string'
+                            and schema_custom == CustomFieldTypes.TEXTAREA.value
+                        ):
+                            # get the value of the extra field
+                            if custom_field_value := work_item.get_editable_custom_field_value(
+                                field_key
+                            ):
+                                if content := self._extract_adf(custom_field_value):
+                                    extra_field_markdown = Markdown(
+                                        content, classes='work-item-info-custom-field-textarea'
+                                    )
+                                    extra_field_markdown.border_title = field_data.get('name')
+                                    self.extra_fields_container.mount(extra_field_markdown)
+                                    self._has_extra_custom_fields = True
+        if self._has_extra_custom_fields:
+            self.extra_fields_container.visible = True
+            self.description_container.styles.height = '50%'
+        else:
+            self.description_container.styles.height = '92%'  # leave some space
+
+    @staticmethod
+    def _extract_adf(data) -> str:
+        try:
+            return adf2md(data)
+        except Exception:
+            return ''
+
+    async def reset_description(self) -> None:
+        await self.issue_description_widget.update('')
+
+    def watch_clear_information(self, clear: bool = False) -> None:
+        if clear:
+            # reset the value of the summary and hide the widget
+            self.issue_summary_widget.update('')
+            self.issue_summary_widget.visible = False
+            self.summary_container_widget.visible = False
+            # reset the value of the description and hide the widget
+            self.run_worker(self.reset_description())
+            self.description_container.visible = False
+            self.issue_description_widget.visible = False
+            # remove the extra fields and hide the widget
+            self.extra_fields_container.visible = False
+            self.extra_fields_container.remove_children()

--- a/uv.lock
+++ b/uv.lock
@@ -528,11 +528,11 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.13"
+version = "2.6.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ca/ffbabe3635bb839aa36b3a893c91a9b0d368cb4d8073e03a12896970af82/identify-2.6.13.tar.gz", hash = "sha256:da8d6c828e773620e13bfa86ea601c5a5310ba4bcd65edf378198b56a1f9fb32", size = 99243, upload-time = "2025-08-09T19:35:00.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/c4/62963f25a678f6a050fb0505a65e9e726996171e6dbe1547f79619eefb15/identify-2.6.14.tar.gz", hash = "sha256:663494103b4f717cb26921c52f8751363dc89db64364cd836a9bf1535f53cd6a", size = 99283, upload-time = "2025-09-06T19:30:52.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl", hash = "sha256:60381139b3ae39447482ecc406944190f690d4a2997f2584062089848361b33b", size = 99153, upload-time = "2025-08-09T19:34:59.1Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl", hash = "sha256:11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e", size = 99172, upload-time = "2025-09-06T19:30:51.759Z" },
 ]
 
 [[package]]
@@ -581,15 +581,14 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "httpx" },
-    { name = "pre-commit" },
     { name = "pydantic-settings", extra = ["yaml"] },
     { name = "python-json-logger" },
     { name = "textual", extra = ["syntax"] },
-    { name = "tonalite" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "textual-dev" },
 ]
 docs = [
@@ -615,15 +614,16 @@ test = [
 requires-dist = [
     { name = "click", specifier = ">=8.2.1" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.10.1" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "textual", extras = ["syntax"], specifier = ">=5.3.0" },
-    { name = "tonalite", specifier = ">=1.8.4" },
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "textual-dev", specifier = ">=1.7.0" }]
+dev = [
+    { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "textual-dev", specifier = ">=1.7.0" },
+]
 docs = [
     { name = "myst-parser", specifier = ">=4.0.1" },
     { name = "sphinx", specifier = ">=8.1.3" },
@@ -1736,15 +1736,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
-]
-
-[[package]]
-name = "tonalite"
-version = "1.8.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/59/b6/713db83b21a4b7c60461766c9ee2111a4f7936096e601cfb6f72f632a7c3/tonalite-1.8.4.tar.gz", hash = "sha256:2a4b19326105f46dd6e0127c1ee96e55c4af9bba68d001aacd257de251e0d0bb", size = 18929, upload-time = "2024-08-28T21:04:54.883Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/98/d50a2757bb4950a7ecc6b8aef9077309db51e533ef044ef500ab1558f14b/tonalite-1.8.4-py3-none-any.whl", hash = "sha256:5a5457b9c8a0df5ab2f304adf4865aad2f0a4491c27f890a9355b847ba73fc06", size = 13752, upload-time = "2024-08-28T21:04:53.703Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "jiratui"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
…work item.

- Display (optional) custom fields of type text/textarea) in the Info tab pane of an issue. Only custom fields that can be edited will be displayed.
- Remove dependency on tonalite because it is not needed.
- Move pre-commit dependency to the dev group
- Add support for additional ADF node types
- Add more tests
- Update tests to use a mock config file
- Show a warning in the comments of an issue when the content of the comment can not be displayed