### PR TITLE
Use python-dateutil to parse datetimes from the Jira API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "click>=8.2.1",
     "httpx>=0.28.1",
     "pydantic-settings[yaml]>=2.10.1",
+    "python-dateutil>=2.9.0.post0",
     "python-json-logger>=3.3.0",
     "textual[syntax]>=5.3.0",
 ]

--- a/src/jiratui/api_controller/controller.py
+++ b/src/jiratui/api_controller/controller.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from dateutil.parser import isoparse  # type:ignore[import-untyped]
+
 from jiratui.api.api import JiraAPI
 from jiratui.api_controller.constants import (
     MAXIMUM_PAGE_NUMBER_LIST_GROUPS,
@@ -1279,8 +1281,8 @@ class APIController:
                     active=author.get('active'),
                     email=author.get('emailAddress'),
                 ),
-                created=datetime.fromisoformat(comment.get('created')),
-                updated=datetime.fromisoformat(comment.get('updated')),
+                created=isoparse(comment.get('created')),
+                updated=isoparse(comment.get('updated')),
                 update_author=JiraUser(
                     account_id=update_author.get('accountId'),
                     display_name=update_author.get('displayName'),
@@ -1327,12 +1329,8 @@ class APIController:
             comments.append(
                 IssueComment(
                     id=record.get('id'),
-                    created=datetime.fromisoformat(record.get('created'))
-                    if record.get('created')
-                    else None,
-                    updated=datetime.fromisoformat(record.get('updated'))
-                    if record.get('updated')
-                    else None,
+                    created=isoparse(record.get('created')) if record.get('created') else None,
+                    updated=isoparse(record.get('updated')) if record.get('updated') else None,
                     author=JiraUser(
                         account_id=author.get('accountId'),
                         active=author.get('active'),
@@ -1376,12 +1374,8 @@ class APIController:
         update_author = response.get('updateAuthor')
         comment = IssueComment(
             id=response.get('id'),
-            created=datetime.fromisoformat(response.get('created'))
-            if response.get('created')
-            else None,
-            updated=datetime.fromisoformat(response.get('updated'))
-            if response.get('updated')
-            else None,
+            created=isoparse(response.get('created')) if response.get('created') else None,
+            updated=isoparse(response.get('updated')) if response.get('updated') else None,
             author=JiraUser(
                 account_id=author.get('accountId'),
                 active=author.get('active'),
@@ -1691,7 +1685,7 @@ class APIController:
                 filename=response[0].get('filename'),
                 size=response[0].get('size'),
                 mime_type=response[0].get('mimeType'),
-                created=datetime.fromisoformat(response[0].get('created'))
+                created=isoparse(response[0].get('created'))
                 if response[0].get('created')
                 else None,
                 author=creator,
@@ -1761,12 +1755,8 @@ class APIController:
                 JiraWorklog(
                     id=work_log.get('id'),
                     issue_id=work_log.get('issueId'),
-                    started=datetime.fromisoformat(work_log.get('started'))
-                    if work_log.get('started')
-                    else None,
-                    updated=datetime.fromisoformat(work_log.get('updated'))
-                    if work_log.get('updated')
-                    else None,
+                    started=isoparse(work_log.get('started')) if work_log.get('started') else None,
+                    updated=isoparse(work_log.get('updated')) if work_log.get('updated') else None,
                     time_spent=work_log.get('timeSpent'),
                     time_spent_seconds=work_log.get('timeSpentSeconds'),
                     author=author,

--- a/src/jiratui/api_controller/factories.py
+++ b/src/jiratui/api_controller/factories.py
@@ -2,6 +2,8 @@ from datetime import datetime
 import json
 from typing import Any
 
+from dateutil.parser import isoparse  # type:ignore[import-untyped]
+
 from jiratui.config import CONFIGURATION
 from jiratui.models import (
     Attachment,
@@ -89,9 +91,7 @@ def build_issue_instance(
                 id=item.get('id'),
                 filename=item.get('filename'),
                 size=item.get('size'),
-                created=datetime.fromisoformat(item.get('created'))
-                if item.get('created')
-                else None,
+                created=isoparse(item.get('created')) if item.get('created') else None,
                 mime_type=item.get('mimeType'),
                 author=creator,
             )
@@ -109,8 +109,8 @@ def build_issue_instance(
         )
         if project
         else None,
-        created=datetime.fromisoformat(fields.get('created')) if fields.get('created') else None,
-        updated=datetime.fromisoformat(fields.get('updated')) if fields.get('updated') else None,
+        created=isoparse(fields.get('created')) if fields.get('created') else None,
+        updated=isoparse(fields.get('updated')) if fields.get('updated') else None,
         priority=IssuePriority(
             id=priority.get('id'),
             name=priority.get('name'),
@@ -143,7 +143,7 @@ def build_issue_instance(
         parent_issue_key=parent_issue_key,
         time_tracking=tracking,
         resolution=fields.get('resolution').get('name') if fields.get('resolution') else None,
-        resolution_date=datetime.fromisoformat(fields.get('resolutiondate'))
+        resolution_date=isoparse(fields.get('resolutiondate'))
         if fields.get('resolutiondate')
         else None,
         labels=[label.lower() for label in fields.get('labels', [])]
@@ -182,12 +182,8 @@ def build_comments(raw_comments: list[dict]) -> list[IssueComment]:
                         active=author.get('active'),
                         email=author.get('emailAddress'),
                     ),
-                    created=datetime.fromisoformat(comment.get('created'))
-                    if comment.get('created')
-                    else None,
-                    updated=datetime.fromisoformat(comment.get('updated'))
-                    if comment.get('updated')
-                    else None,
+                    created=isoparse(comment.get('created')) if comment.get('created') else None,
+                    updated=isoparse(comment.get('updated')) if comment.get('updated') else None,
                     update_author=JiraUser(
                         account_id=update_author.get('accountId'),
                         display_name=update_author.get('displayName'),

--- a/src/jiratui/widgets/screens.py
+++ b/src/jiratui/widgets/screens.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date
 import logging
 
+from dateutil.parser import isoparse  # type:ignore[import-untyped]
 from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -556,11 +557,11 @@ class MainScreen(Screen):
 
         search_field_created_from: date | None = None
         if value := self.issue_date_from_input.value:
-            search_field_created_from = datetime.fromisoformat(value).date()
+            search_field_created_from = isoparse(value).date()
 
         search_field_created_until: date | None = None
         if value := self.issue_date_until_input.value:
-            search_field_created_until = datetime.fromisoformat(value).date()
+            search_field_created_until = isoparse(value).date()
 
         search_field_assignee: str | None = None
         if value := self.users_selector.selection:

--- a/uv.lock
+++ b/uv.lock
@@ -582,6 +582,7 @@ dependencies = [
     { name = "click" },
     { name = "httpx" },
     { name = "pydantic-settings", extra = ["yaml"] },
+    { name = "python-dateutil" },
     { name = "python-json-logger" },
     { name = "textual", extra = ["syntax"] },
 ]
@@ -615,6 +616,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.2.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.10.1" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "textual", extras = ["syntax"], specifier = ">=5.3.0" },
 ]
@@ -1295,6 +1297,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1429,6 +1443,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/c1/5f9a839a697ce1acd7af44836f7c2181cdae5accd17a5cb85fcbd694075e/ruff-0.12.9-py3-none-win32.whl", hash = "sha256:cc7a37bd2509974379d0115cc5608a1a4a6c4bff1b452ea69db83c8855d53f93", size = 11734785, upload-time = "2025-08-14T16:08:48.062Z" },
     { url = "https://files.pythonhosted.org/packages/fa/66/cdddc2d1d9a9f677520b7cfc490d234336f523d4b429c1298de359a3be08/ruff-0.12.9-py3-none-win_amd64.whl", hash = "sha256:6fb15b1977309741d7d098c8a3cb7a30bc112760a00fb6efb7abc85f00ba5908", size = 12840654, upload-time = "2025-08-14T16:08:50.158Z" },
     { url = "https://files.pythonhosted.org/packages/ac/fd/669816bc6b5b93b9586f3c1d87cd6bc05028470b3ecfebb5938252c47a35/ruff-0.12.9-py3-none-win_arm64.whl", hash = "sha256:63c8c819739d86b96d500cce885956a1a48ab056bbcbc61b747ad494b2485089", size = 11949623, upload-time = "2025-08-14T16:08:52.233Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This fixes an issue that occurs when parsing `datetime` values returned by the Jira API in Python 3.10.

Instead of using Python's `datetime` let's use `python-dateutil`'s `isoparse.parse()`

Closes #21