### PR TITLE
docs: add homebrew install informations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ For Arch Linux (btw) the package is available in [AUR](https://aur.archlinux.org
 yay -S jiratui-git
 ```
 
+You can also install using homebrew
+
+```shell
+brew install jiratui
+```
+
 ## Usage
 
 After installing the package, you can run the CLI tool with the following command:

--- a/docs/users/install/index.md
+++ b/docs/users/install/index.md
@@ -24,6 +24,12 @@ For Arch Linux (btw) the package is available in [AUR](https://aur.archlinux.org
 yay -S jiratui-git
 ```
 
+You can also install using homebrew
+
+```shell
+brew install jiratui
+```
+
 After installing the package, you can run the CLI tool with the following command:
 
 ```shell


### PR DESCRIPTION
`jiratui` is available through [homebrew](https://formulae.brew.sh/formula/jiratui) since https://github.com/Homebrew/homebrew-core/pull/245828