### PR TITLE
search_on_startup: config value was always overridden by CLI

### DIFF
--- a/src/jiratui/cli.py
+++ b/src/jiratui/cli.py
@@ -476,7 +476,9 @@ def ui(
 
     try:
         settings = ApplicationConfiguration()  # type: ignore[call-arg] # noqa
-        settings.search_on_startup = search_on_startup
+        # Only override config file value if CLI flag is explicitly set to True
+        if search_on_startup:
+            settings.search_on_startup = search_on_startup
     except FileNotFoundError as e:
         console.print(e)
         sys.exit(1)


### PR DESCRIPTION
The config value for searching on startup had no effect since the CLI option would always end up controlling it. Only overriding the config if the CLI sets true. If config is false, the CLI will have precedence as it's to be expected.