### PR TITLE
JT-14: use relative URLs when fetching attachment contents when using Jira DC instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ autocomplete feature there is no need to fetch all the users anymore.
 
 - Use the `--assignee-account-id` cli argument, in addition to the `config.jira_account_id` value to pre-define the
 default reporting user when creating work items.
+- Use relative URLs to download attachments when the user uses Jra DC instance.
 
 ### Minor Improvements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "textual-autocomplete>=4.0.6",
     "textual-image>=0.8.5,<0.9.0",
     "textual[syntax]>=8.2.0,<9.0.0",
+    "urllib3>=2.6.3,<2.7.0",
     "xdg-base-dirs>=6.0.2",
 ]
 

--- a/src/jiratui/api/api.py
+++ b/src/jiratui/api/api.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import httpx
 import puremagic
+from urllib3.util import parse_url
 
 from jiratui.api.client import AsyncJiraClient, JiraClient, JiraTUIAsyncHTTPClient
 from jiratui.api.utils import build_issue_search_jql
@@ -1560,9 +1561,17 @@ class JiraDataCenterAPI(JiraAPI):
         Returns:
             A bytes representation of the attachment's content; or `None` if the attachment can not be downloaded.
         """
+
         attachment: dict
         if attachment := await self.get_attachment(attachment_id):
             if content := attachment.get('content'):
+                # extract relative URL because Jira DC returns absolute URL
+                if parsed := parse_url(content):
+                    content = parsed.path.lstrip('/')
+                    if parsed.query:
+                        content += '?' + parsed.query
+                    if parsed.fragment:
+                        content += '#' + parsed.fragment
                 await self._async_http_client.make_request(
                     method=httpx.AsyncClient.get,
                     url=content,

--- a/src/jiratui/api/tests/test_api.py
+++ b/src/jiratui/api/tests/test_api.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timezone
 import json
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import AsyncMock, Mock, mock_open, patch
 
 import httpx
 import pytest
 import respx
 
-from jiratui.api.api import JiraAPI, JiraDataCenterAPI
+from jiratui.api.api import JiraAPI, JiraAPIv2, JiraDataCenterAPI
 from jiratui.api.utils import build_issue_search_jql
 from jiratui.exceptions import FileUploadException
 from jiratui.models import WorkItemsSearchOrderBy
@@ -1354,7 +1354,7 @@ async def test_add_comment(jira_api: JiraAPI):
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_add_comment_with_api_v2(jira_api_v2: JiraAPI):
+async def test_add_comment_with_api_v2(jira_api_v2: JiraAPIv2):
     # GIVEN
     route = respx.post(get_url_pattern('issue/1/comment'))
     route.mock(
@@ -3082,3 +3082,105 @@ async def test_get_user(jira_api: JiraAPI):
         'key': '',
         'name': '',
     }
+
+
+@patch.object(JiraDataCenterAPI, 'get_attachment')
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_attachment_content_using_jira_dc(
+    get_attachment_mock: AsyncMock, jira_api_dc: JiraDataCenterAPI
+):
+    # GIVEN
+    get_attachment_mock.return_value = {'content': 'https://foo.bar/path/filename.abc?q=1#f2'}
+    route = respx.get('https://foo.bar/rest/api/2/path/filename.abc?q=1')
+    route.mock(
+        return_value=httpx.Response(
+            200,
+            json={},
+        )
+    )
+    # WHEN
+    await jira_api_dc.get_attachment_content('1')
+    # THEN
+    assert route.calls.last.request.url.path == '/rest/api/2/path/filename.abc'
+
+
+@patch.object(JiraDataCenterAPI, 'get_attachment')
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_attachment_content_using_jira_dc_with_empty_content(
+    get_attachment_mock: AsyncMock,
+    jira_api_dc: JiraDataCenterAPI,
+):
+    # GIVEN
+    get_attachment_mock.return_value = {'content': ''}
+    # WHEN
+    result = await jira_api_dc.get_attachment_content('1')
+    # THEN
+    assert result is None
+
+
+@patch.object(JiraDataCenterAPI, 'get_attachment')
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_attachment_content_using_jira_dc_with_empty_attachment(
+    get_attachment_mock: AsyncMock,
+    jira_api_dc: JiraDataCenterAPI,
+):
+    # GIVEN
+    get_attachment_mock.return_value = None
+    # WHEN
+    result = await jira_api_dc.get_attachment_content('1')
+    # THEN
+    assert result is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_attachment_using_jira_dc(jira_api_dc: JiraDataCenterAPI):
+    # GIVEN
+    route = respx.get(get_url_pattern('attachment/1'))
+    route.mock(
+        return_value=httpx.Response(
+            200,
+            json={},
+        )
+    )
+    # WHEN
+    await jira_api_dc.get_attachment('1')
+    # THEN
+    assert route.calls.last.request.url.path == '/rest/api/2/attachment/1'
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_attachment(jira_api: JiraAPI):
+    # GIVEN
+    route = respx.get(get_url_pattern('attachment/1'))
+    route.mock(
+        return_value=httpx.Response(
+            200,
+            json={},
+        )
+    )
+    # WHEN
+    await jira_api.get_attachment('1')
+    # THEN
+    assert route.calls.last.request.url.path == '/rest/api/3/attachment/1'
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_get_attachment_content(jira_api: JiraAPI):
+    # GIVEN
+    route = respx.get(get_url_pattern('attachment/content/1'))
+    route.mock(
+        return_value=httpx.Response(
+            200,
+            json={},
+        )
+    )
+    # WHEN
+    await jira_api.get_attachment_content('1')
+    # THEN
+    assert route.calls.last.request.url.path == '/rest/api/3/attachment/content/1'

--- a/uv.lock
+++ b/uv.lock
@@ -577,6 +577,7 @@ dependencies = [
     { name = "textual", extra = ["syntax"] },
     { name = "textual-autocomplete" },
     { name = "textual-image" },
+    { name = "urllib3" },
     { name = "xdg-base-dirs" },
 ]
 
@@ -616,6 +617,7 @@ requires-dist = [
     { name = "textual", extras = ["syntax"], specifier = ">=8.2.0,<9.0.0" },
     { name = "textual-autocomplete", specifier = ">=4.0.6" },
     { name = "textual-image", specifier = ">=0.8.5,<0.9.0" },
+    { name = "urllib3", specifier = ">=2.6.3,<2.7.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 


### PR DESCRIPTION
Solves https://github.com/whyisdifficult/jiratui/issues/194
Closes https://github.com/whyisdifficult/jiratui/issues/194