### PR TITLE
Support the type number when adding new work items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `textual-autocomplete` to define a widget for selecting Jira users as assignees when creating work items.
 - Use `textual-autocomplete` to define a widget for selecting Jira users as reporters when creating work items.
 - Add support for updating the reporter of a work item.
+- Support for fields with `type:number` when we create new work items.
 
 ### Changed
 

--- a/src/jiratui/widgets/create_work_item/factory.py
+++ b/src/jiratui/widgets/create_work_item/factory.py
@@ -251,6 +251,7 @@ FIELDS_IDS_NOT_SUPPORTED = [
 # will cause errors when creating the items; as their values are not simply strings.
 CUSTOM_FIELD_TYPES_NOT_SUPPORTED = [
     'com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team',
+    'com.pyxis.greenhopper.jira:gh-lexo-rank',  # this requires special syntax
 ]
 
 CREATE_FORM_DEFAULT_FIELDS_IDS: list[str] = [

--- a/src/jiratui/widgets/create_work_item/screen.py
+++ b/src/jiratui/widgets/create_work_item/screen.py
@@ -441,7 +441,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
         if custom_type == CustomFieldType.USER_PICKER.value:
             return {'accountId': value}
 
-        elif custom_type == CustomFieldType.FLOAT.value:
+        elif custom_type == CustomFieldType.FLOAT.value or schema.get('type') == 'number':
             if value:  # Type-safe check to prevent ~AlwaysFalsy error
                 try:
                     return float(value)

--- a/src/jiratui/widgets/create_work_item/tests/test_create_work_item.py
+++ b/src/jiratui/widgets/create_work_item/tests/test_create_work_item.py
@@ -1092,7 +1092,7 @@ def test_jira_field_key_for_additional_fields(config_for_testing):
         elif widget.id == 'user-picker':
             assert widget.jira_field_key == 'user-picker'
             assert isinstance(widget, UserPickerWidget)
-    assert len(widgets) == 15
+    assert len(widgets) == 14
 
 
 def test_jira_field_key_for_non_required_additional_fields_with_ignore_list(app):

--- a/src/jiratui/widgets/create_work_item/tests/test_create_work_item.py
+++ b/src/jiratui/widgets/create_work_item/tests/test_create_work_item.py
@@ -1527,6 +1527,26 @@ async def test_format_field_value_with_custom_type_float_and_correct_value(app):
         assert result == float('1.2')
 
 
+@pytest.mark.asyncio
+async def test_format_field_value_with_type_number(app):
+    # GIVEN
+    app.config.create_additional_fields_ignore_ids = []
+    app.config.enable_creating_additional_fields = True
+    metadata = {
+        'schema': {
+            'type': 'number',
+        }
+    }
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='TEST')
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN
+        result = screen._format_field_value('field_a', '1.2', metadata)
+        # THEN
+        assert result == float('1.2')
+
+
 @pytest.mark.parametrize(
     'field_value, expected',
     [


### PR DESCRIPTION
This PR adds support for creating fields of type `number` when adding a new work item.