### PR TITLE
Feature/JT-21 update results after delete

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-toml
+      - id: debug-statements
       - id: check-added-large-files
         args: ['--maxkb=800']
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -14,7 +15,7 @@ repos:
     rev: v0.15.8
     hooks:
       # Run the linter.
-      - id: ruff-check
+      - id: ruff
         args: [--fix]
       # Run the formatter.
       - id: ruff-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `textual-autocomplete` to define a widget for selecting Jira users as reporters when creating work items.
 - Add support for updating the reporter of a work item.
 - Support for fields with `type:number` when we create new work items.
+- Update the search results table after deleting a work item; by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/205
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,16 +29,16 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "click>=8.3.1,<9.0.0",
+    "click>=8.3.2,<9.0.0",
     "gitpython>=3.1.46,<3.2.0",
     "httpx>=0.28.1",
-    "puremagic>=2.1.1",
+    "puremagic>=2.2.0,<3.0.0",
     "pydantic-settings[yaml]>=2.13.1,<3.0.0",
     "python-dateutil>=2.9.0.post0",
-    "python-json-logger>=4.0.0",
+    "python-json-logger>=4.1.0,<5.0.0",
     "textual-autocomplete>=4.0.6",
-    "textual-image>=0.8.5,<0.9.0",
-    "textual[syntax]>=8.2.0,<9.0.0",
+    "textual-image>=0.12.0,<0.13.0",
+    "textual[syntax]>=8.2.3,<9.0.0",
     "urllib3>=2.6.3,<2.7.0",
     "xdg-base-dirs>=6.0.2",
 ]

--- a/src/jiratui/tests/test_search_results.py
+++ b/src/jiratui/tests/test_search_results.py
@@ -9,7 +9,11 @@ from jiratui.app import JiraApp
 from jiratui.config import ApplicationConfiguration
 from jiratui.models import JiraIssue, JiraIssueSearchResponse, WorkItemsSearchOrderBy
 from jiratui.widgets.screens import MainScreen, WorkItemSearchResult
-from jiratui.widgets.search import ConfirmDeleteItemScreen, IssuesSearchResultsTable
+from jiratui.widgets.search import (
+    ConfirmDeleteItemScreen,
+    IssuesSearchResultsTable,
+    SearchResultsContainer,
+)
 
 
 @pytest.fixture()
@@ -438,6 +442,7 @@ async def test_open_delete_issue_modal_screen(
         assert isinstance(app.screen, ConfirmDeleteItemScreen)
 
 
+@patch.object(SearchResultsContainer, '_update_border_subtitle')
 @patch('jiratui.widgets.screens.MainScreen._search_work_items')
 @patch('jiratui.widgets.screens.MainScreen.fetch_statuses')
 @patch('jiratui.widgets.screens.MainScreen.fetch_issue_types')
@@ -448,6 +453,7 @@ async def test_delete_issue_modal_screen_click_cancel(
     fetch_issue_types_mock: AsyncMock,
     fetch_statuses_mock: AsyncMock,
     search_work_items_mock: AsyncMock,
+    update_border_subtitle_mock: Mock,
     jira_issues: list[JiraIssue],
     app,
 ):
@@ -480,19 +486,22 @@ async def test_delete_issue_modal_screen_click_cancel(
         )
         assert main_screen.search_results_table.current_work_item_key == jira_issues[1].key
         assert isinstance(app.screen, MainScreen)
+        update_border_subtitle_mock.assert_called_once()
 
 
 @patch.object(APIController, 'delete_work_item')
+@patch.object(SearchResultsContainer, '_update_border_subtitle')
 @patch('jiratui.widgets.screens.MainScreen._search_work_items')
 @patch('jiratui.widgets.screens.MainScreen.fetch_statuses')
 @patch('jiratui.widgets.screens.MainScreen.fetch_issue_types')
 @patch('jiratui.widgets.screens.MainScreen.fetch_projects')
 @pytest.mark.asyncio
 async def test_delete_issue_modal_screen_click_delete(
-    search_projects_mock: AsyncMock,
+    fetch_projects_mock: AsyncMock,
     fetch_issue_types_mock: AsyncMock,
     fetch_statuses_mock: AsyncMock,
     search_work_items_mock: AsyncMock,
+    update_border_subtitle_mock: Mock,
     delete_work_item_mock: AsyncMock,
     jira_issues: list[JiraIssue],
     app,
@@ -524,6 +533,61 @@ async def test_delete_issue_modal_screen_click_delete(
         assert main_screen.search_results_table.search_results == JiraIssueSearchResponse(
             issues=jira_issues, next_page_token=None, is_last=None
         )
-        assert main_screen.search_results_table.current_work_item_key == jira_issues[1].key
+        assert main_screen.search_results_table.current_work_item_key != jira_issues[1].key
         assert isinstance(app.screen, MainScreen)
         delete_work_item_mock.assert_called_once_with(jira_issues[1].key)
+        update_border_subtitle_mock.assert_has_calls([call(), call()])
+
+
+@patch.object(APIController, 'delete_work_item')
+@patch.object(SearchResultsContainer, '_update_border_subtitle')
+@patch('jiratui.widgets.screens.MainScreen._search_work_items')
+@patch('jiratui.widgets.screens.MainScreen.fetch_statuses')
+@patch('jiratui.widgets.screens.MainScreen.fetch_issue_types')
+@patch('jiratui.widgets.screens.MainScreen.fetch_projects')
+@pytest.mark.asyncio
+async def test_delete_issue_modal_screen_click_delete_currently_selected_item(
+    fetch_projects_mock: AsyncMock,
+    fetch_issue_types_mock: AsyncMock,
+    fetch_statuses_mock: AsyncMock,
+    search_work_items_mock: AsyncMock,
+    update_border_subtitle_mock: Mock,
+    delete_work_item_mock: AsyncMock,
+    jira_issues: list[JiraIssue],
+    app,
+):
+    """Tests that deleting the currently select item clears the currently selected item key and the details' issue."""
+    app.config.search_results_truncate_work_item_summary = 10
+    app.config.search_results_style_work_item_status = False
+    app.config.search_results_style_work_item_type = False
+    app.config.search_results_per_page = 10
+    delete_work_item_mock.return_value = APIControllerResponse()
+    async with app.run_test() as pilot:
+        # GIVEN
+        search_work_items_mock.return_value = WorkItemSearchResult(
+            total=2,
+            response=JiraIssueSearchResponse(
+                issues=jira_issues, next_page_token=None, is_last=None
+            ),
+        )
+        main_screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        main_screen.current_loaded_work_item_key = jira_issues[1].key
+        # WHEN
+        await pilot.press('ctrl+r')
+        await pilot.press('down')
+        await pilot.press('down')
+        await pilot.press('d')
+        await pilot.press('enter')
+        # THEN
+        assert main_screen.search_results_table.focus()
+        assert main_screen.search_results_table.page == 1
+        search_work_items_mock.assert_called_once()
+        assert main_screen.search_results_table.search_results == JiraIssueSearchResponse(
+            issues=jira_issues, next_page_token=None, is_last=None
+        )
+        assert main_screen.search_results_table.current_work_item_key != jira_issues[1].key
+        assert isinstance(app.screen, MainScreen)
+        delete_work_item_mock.assert_called_once_with(jira_issues[1].key)
+        update_border_subtitle_mock.assert_has_calls([call(), call()])
+        assert main_screen.current_loaded_work_item_key is None
+        assert main_screen.issue_details_widget.issue is None

--- a/src/jiratui/widgets/related_work_items/related_issues.py
+++ b/src/jiratui/widgets/related_work_items/related_issues.py
@@ -130,7 +130,7 @@ class RelatedIssuesWidget(VerticalScroll):
             )
         else:
             self.notify(
-                'Select a work item before attempting to add a link.',
+                'Select a work item before attempting to link work items.',
                 title=self.NOTIFICATIONS_DEFAULT_TITLE,
             )
 

--- a/src/jiratui/widgets/remote_links/links.py
+++ b/src/jiratui/widgets/remote_links/links.py
@@ -194,7 +194,6 @@ class IssueRemoteLinksWidget(VerticalScroll):
                 )
             )
 
-        await self.remove_children()
         await self.mount_all(rows)
 
     def watch_issue_key(self, issue_key: str | None = None) -> None:
@@ -206,5 +205,7 @@ class IssueRemoteLinksWidget(VerticalScroll):
         Returns:
             Nothing.
         """
+
+        self.remove_children()
         if issue_key:
             self.run_worker(self.fetch_remote_links(issue_key))

--- a/src/jiratui/widgets/screens.py
+++ b/src/jiratui/widgets/screens.py
@@ -1145,16 +1145,14 @@ class MainScreen(Screen):
 
         result: JiraIssueSearchResponse = response.result
         work_item: JiraIssue = result.issues[0]
+        # track the currently loaded work item
+        self.current_loaded_work_item_key = work_item.key
 
         # step 2: populate information tab
         self.issue_info_container.issue = work_item
         self.issue_info_container.hide_loading()
 
-        # track the currently loaded work item
-        self.current_loaded_work_item_key = selected_work_item_key
-
         # step 3: populate the details tab
-        # set the work item
         self.issue_details_widget.issue = work_item
 
         # step 4: populate the related-issues tab
@@ -1169,11 +1167,11 @@ class MainScreen(Screen):
         self.issue_attachments_widget.issue_key = work_item.key
         self.issue_attachments_widget.attachments = work_item.attachments
 
-        # fetch the issue's web links
+        # step 7: populate links tab
         if CONFIGURATION.get().show_issue_web_links:
             self.issue_remote_links_widget.issue_key = work_item.key
 
-        # fetch sub-tasks
+        # step 8: populate subtasks tab
         self.run_worker(self.retrieve_issue_subtasks(work_item.key))
 
     async def request_text_search(self, value: str):
@@ -1265,3 +1263,30 @@ class MainScreen(Screen):
 
         # Shift focus to the issue info container so user can interact with the issue
         self.issue_info_container.focus()
+
+    @on(IssuesSearchResultsTable.WorkItemDeleted)
+    def clear_work_item_data(self, message: IssuesSearchResultsTable.WorkItemDeleted) -> None:
+        """Clears the data of a selected item when the item is deleted.
+
+        When a work item is deleted and the item is the one currently being displayed in the information tabs on the
+        right-hand panel let's make sure we clean the forms and widgets. This way we avoid displaying the details of
+        the item that was deleted. This is only done when the item deleted is the one currently being displayed.
+
+        Args:
+            message: the message sent by a widget, e.g. the DataTable that holds the search results, when a work item is
+            deleted. The message contains the key of the work item that was deleted.
+
+        Returns:
+            None
+        """
+
+        if self.current_loaded_work_item_key == message.work_item_key:
+            # clean up the forms and tabs
+            self.related_issues_widget.remove_children()
+            self.issue_comments_widget.remove_children()
+            self.issue_attachments_widget.remove_children()
+            self.issue_remote_links_widget.remove_children()
+            self.issue_child_work_items_widget.remove_children()
+            self.issue_info_container.clear_information = True
+            self.issue_details_widget.issue = None
+            self.current_loaded_work_item_key = None

--- a/src/jiratui/widgets/screens.py
+++ b/src/jiratui/widgets/screens.py
@@ -1282,11 +1282,15 @@ class MainScreen(Screen):
 
         if self.current_loaded_work_item_key == message.work_item_key:
             # clean up the forms and tabs
-            self.related_issues_widget.remove_children()
-            self.issue_comments_widget.remove_children()
-            self.issue_attachments_widget.remove_children()
-            self.issue_remote_links_widget.remove_children()
-            self.issue_child_work_items_widget.remove_children()
-            self.issue_info_container.clear_information = True
+            self.related_issues_widget.issues = None
+            self.related_issues_widget.issue_key = None
+            self.issue_comments_widget.comments = None
+            self.issue_comments_widget.issue_key = None
+            self.issue_attachments_widget.attachments = None
+            self.issue_attachments_widget.issue_key = None
+            self.issue_remote_links_widget.issue_key = None
+            self.issue_child_work_items_widget.issues = None
+            self.issue_child_work_items_widget.issue_key = None
+            self.issue_info_container.issue = None
             self.issue_details_widget.issue = None
             self.current_loaded_work_item_key = None

--- a/src/jiratui/widgets/search.py
+++ b/src/jiratui/widgets/search.py
@@ -5,9 +5,11 @@ from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, ItemGrid, Vertical
+from textual.message import Message
 from textual.reactive import Reactive, reactive
 from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Input, Rule, Static
+from textual.widgets._data_table import RowDoesNotExist
 
 from jiratui.api_controller.controller import APIControllerResponse
 from jiratui.config import CONFIGURATION
@@ -130,7 +132,20 @@ class DataTableSearchInput(Input):
 
 
 class IssuesSearchResultsTable(DataTable):
-    """The widgets that displays the results of a search."""
+    """The widget that displays the results of a search.
+
+    This widget provides a reactive attribute, `search_results`, that contains the issues that the table will
+    display.
+
+    The widget can post a message of type `IssuesSearchResultsTable.WorkItemDeleted` when the user deletes an item from
+    the table.
+
+    ```{important}
+    Deleting an item will delete the item from Jira. After a successful deletion the datatable will remove the row
+    related to the item that was deleted. In addition, the widget will send the message
+    `IssuesSearchResultsTable.WorkItemDeleted` to notify other widgets so they can update the relevant widgets.
+    ```
+    """
 
     search_results: Reactive[JiraIssueSearchResponse | None] = reactive(None, always_update=True)
 
@@ -178,6 +193,15 @@ class IssuesSearchResultsTable(DataTable):
 
     SMALLEST_MAXIMUM_WIDTH_FOR_SUMMARY_COLUMN = 30
 
+    class WorkItemDeleted(Message):
+        def __init__(self, work_item_key: str) -> None:
+            self._work_item_key = work_item_key
+            super().__init__()
+
+        @property
+        def work_item_key(self) -> str:
+            return self._work_item_key
+
     def __init__(self):
         super().__init__(id='search_results', cursor_type='row')
         # stores the next page's token by page number
@@ -188,6 +212,7 @@ class IssuesSearchResultsTable(DataTable):
         self.token_by_page: dict[int, str] = {}
         self.page = 1
         self.current_work_item_key: str | None = None
+        self.current_work_item_id: str | None = None
         self._initial_results_set: JiraIssueSearchResponse | None = None
 
     def set_initial_results_set(self, data: JiraIssueSearchResponse | None = None):
@@ -252,17 +277,18 @@ class IssuesSearchResultsTable(DataTable):
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         """Fetches the details of the currently-selected item."""
-        screen = cast('MainScreen', self.screen)  # type:ignore[name-defined] # noqa: F821
-        _, work_item_key = event.row_key.value.split('#')
-        self.current_work_item_key = work_item_key
-        # use exclusive=True to make sure that if the user selects another work item before the worker finishes
-        # retrieving the data of the previously selected the correct data is fetched
-        # the exclusive flag tells Textual to cancel all previous workers before starting the new one.
-        self.run_worker(screen.fetch_issue(work_item_key), exclusive=True)
+        if event.row_key:
+            screen = cast('MainScreen', self.screen)  # type:ignore[name-defined] # noqa: F821
+            self.current_work_item_id, self.current_work_item_key = event.row_key.value.split('#')
+            # use exclusive=True to make sure that if the user selects another work item before the worker finishes
+            # retrieving the data of the previously selected the correct data is fetched
+            # the exclusive flag tells Textual to cancel all previous workers before starting the new one.
+            self.run_worker(screen.fetch_issue(self.current_work_item_key), exclusive=True)
 
     def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
         """Stores the key of the currently-selected item."""
-        _, self.current_work_item_key = event.row_key.value.split('#')
+        if event.row_key:
+            self.current_work_item_id, self.current_work_item_key = event.row_key.value.split('#')
 
     def action_open_issue_in_browser(self) -> None:
         """Opens the currently-selected item in the default browser."""
@@ -308,9 +334,18 @@ class IssuesSearchResultsTable(DataTable):
                 self.current_work_item_key
             )
             if response.success:
-                self.notify(
-                    f'{self.current_work_item_key} deleted successfully', title='Delete Work Item'
-                )
+                try:
+                    self.remove_row(f'{self.current_work_item_id}#{self.current_work_item_key}')
+                except RowDoesNotExist:
+                    pass
+                else:
+                    # post the message to the parent container can update the pagination legend
+                    self.post_message(self.WorkItemDeleted(self.current_work_item_key))
+                    # force the table to highlight another item to avoid RowDoesNotExist exceptions with the next delete
+                    # attempt
+                    self.action_cursor_up()
+                    self.action_cursor_down()
+                self.notify(f'Deleted {self.current_work_item_key}', title='Delete Work Item')
             else:
                 self.notify(
                     f'Failed to delete the item {self.current_work_item_key}.',
@@ -383,24 +418,49 @@ class IssuesSearchResultsTable(DataTable):
 
 
 class SearchResultsContainer(Container):
-    """The container that holds the search results."""
+    """The container that holds the DataTable widget with the search results.
+
+    This widget provides a reactive attribute called `pagination`. The attribute accepts a dictionary with the details
+    of the search results' pagination. This includes `current_page_number` and `total`. When this attribute is updated
+    the widget will update the legend in the border subtitle to display the number of results and the page number.
+    """
 
     pagination: Reactive[dict | None] = reactive(None)
+    """Reactive attribute that contains pagination details associated to the search results. This is used setting the
+    widget's border subtitle with the page number and total records in the result."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.border_title = 'Work Items'
         self.config = CONFIGURATION.get()
+        self._total_results = None
+        self._page_number = None
+        self._total_pages = None
+
+    def _update_border_subtitle(self) -> None:
+        if self._total_results is None:
+            self.border_subtitle = (
+                None if self._page_number is None else f'Page {self._page_number}'
+            )
+        else:
+            self._total_pages = self._total_results // self.config.search_results_per_page
+            if (self._total_results % self.config.search_results_per_page) > 0:
+                self._total_pages += 1
+            if self._page_number is not None:
+                self.border_subtitle = f'Page {self._page_number} of {self._total_pages} (total: {self._total_results})'
+            else:
+                self.border_subtitle = None
 
     def watch_pagination(self, response: dict) -> None:
         if response:
-            current_page_number = max(1, response.get('current_page_number'))
-            if (total_results := response.get('total', 0)) is not None:
-                total_pages = total_results // self.config.search_results_per_page
-                if (total_results % self.config.search_results_per_page) > 0:
-                    total_pages += 1
-                self.border_subtitle = (
-                    f'Page {current_page_number} of {total_pages} (total: {total_results})'
-                )
-            else:
-                self.border_subtitle = f'Page {current_page_number}'
+            self._page_number = max(1, response.get('current_page_number'))
+            self._total_results = response.get('total', 0)
+            self._update_border_subtitle()
+
+    @on(IssuesSearchResultsTable.WorkItemDeleted)
+    def update_pagination_details_after_delete(
+        self, message: IssuesSearchResultsTable.WorkItemDeleted
+    ) -> None:
+        # update the total number of records and the border legend
+        self._total_results = 0 if self._total_results is None else self._total_results - 1
+        self._update_border_subtitle()

--- a/src/jiratui/widgets/subtasks.py
+++ b/src/jiratui/widgets/subtasks.py
@@ -73,15 +73,20 @@ class IssueChildWorkItemsWidget(VerticalScroll):
         self._issue_key = value
 
     async def action_create_work_item_subtask(self) -> None:
-        screen = cast('MainScreen', self.screen)  # type:ignore[name-defined] # noqa: F821
-        await self.app.push_screen(
-            AddWorkItemScreen(
-                project_key=screen.project_selector.selection,
-                reporter_account_id=CONFIGURATION.get().jira_account_id,
-                parent_work_item_key=self.issue_key,
-            ),
-            callback=screen.create_work_item,
-        )
+        if self._issue_key:
+            screen = cast('MainScreen', self.screen)  # type:ignore[name-defined] # noqa: F821
+            await self.app.push_screen(
+                AddWorkItemScreen(
+                    project_key=screen.project_selector.selection,
+                    reporter_account_id=CONFIGURATION.get().jira_account_id,
+                    parent_work_item_key=self.issue_key,
+                ),
+                callback=screen.create_work_item,
+            )
+        else:
+            self.notify(
+                'Select a work item before attempting to create a subtask.', title='Create Subtask'
+            )
 
     def watch_issues(self, items: list[JiraIssue]) -> None:
         """Updates the list of work items that are subtasks of the currently-selected item.

--- a/uv.lock
+++ b/uv.lock
@@ -234,14 +234,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]
@@ -607,16 +607,16 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.3.1,<9.0.0" },
+    { name = "click", specifier = ">=8.3.2,<9.0.0" },
     { name = "gitpython", specifier = ">=3.1.46,<3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "puremagic", specifier = ">=2.1.1" },
+    { name = "puremagic", specifier = ">=2.2.0,<3.0.0" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.13.1,<3.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
-    { name = "python-json-logger", specifier = ">=4.0.0" },
-    { name = "textual", extras = ["syntax"], specifier = ">=8.2.0,<9.0.0" },
+    { name = "python-json-logger", specifier = ">=4.1.0,<5.0.0" },
+    { name = "textual", extras = ["syntax"], specifier = ">=8.2.3,<9.0.0" },
     { name = "textual-autocomplete", specifier = ">=4.0.6" },
-    { name = "textual-image", specifier = ">=0.8.5,<0.9.0" },
+    { name = "textual-image", specifier = ">=0.12.0,<0.13.0" },
     { name = "urllib3", specifier = ">=2.6.3,<2.7.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
@@ -1211,11 +1211,11 @@ wheels = [
 
 [[package]]
 name = "puremagic"
-version = "2.1.1"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/df/3725f4b848095ef634c0b2226c97901e64ee2d5a82981d89d4b784ae8ce1/puremagic-2.1.1.tar.gz", hash = "sha256:b156c4ae63d84842f92a85cd49c9b9029a4f107f98ad14e7584ed652954feff4", size = 1133417, upload-time = "2026-03-23T19:08:46.929Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/74/ce5987ab9b8aec4ced06e2723ebb604205c9eb58abdad91453da93166380/puremagic-2.2.0.tar.gz", hash = "sha256:eb4bddf07c177c4b434554b92165b67449f5a51e152b976202d6254498810eef", size = 1189752, upload-time = "2026-04-08T01:39:55.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/d0/12b1d4113fd6660a0a75e8c40500c5d1c4febd8e24dc85aaf20cfd93e9d6/puremagic-2.1.1-py3-none-any.whl", hash = "sha256:b8862451f96254358a6e2ea7fba46e0600cf8b13ebe917d6eecdb18fc22db964", size = 68025, upload-time = "2026-03-23T19:08:45.872Z" },
+    { url = "https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl", hash = "sha256:c4f7ed7307f056c787199acfda839555921be1df13abba61e8e6db0c787ae1d0", size = 71971, upload-time = "2026-04-08T01:39:54.169Z" },
 ]
 
 [[package]]
@@ -1411,11 +1411,11 @@ wheels = [
 
 [[package]]
 name = "python-json-logger"
-version = "4.0.0"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]
@@ -1713,7 +1713,7 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "8.2.0"
+version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -1723,9 +1723,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/41/fd22435b96a50f24472af31f15e9874ce0ffef0edabb74fcf3d598ab8e53/textual-8.2.0.tar.gz", hash = "sha256:a06201a732b2d2683d2ea11c2538eeb7315c4c7138ed8c8bdb48150b805eaf1e", size = 1847670, upload-time = "2026-03-27T09:28:29.976Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/2f/d44f0f12b3ddb1f0b88f7775652e99c6b5a43fd733badf4ce064bdbfef4a/textual-8.2.3.tar.gz", hash = "sha256:beea7b86b03b03558a2224f0cc35252e60ef8b0c4353b117b2f40972902d976a", size = 1848738, upload-time = "2026-04-05T09:12:45.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/41/ed1f3e47b71b9e0bae23445189274048332a423798627d47e30314c739a0/textual-8.2.0-py3-none-any.whl", hash = "sha256:0478fed6e945bcadd6f3841e10d05213d318cdb5c4345c04ae78f7ec32e7b63d", size = 723752, upload-time = "2026-03-27T09:28:32.705Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/28/a81d6ce9f4804818bd1231a9a6e4d56ea84ebbe8385c49591444f0234fa2/textual-8.2.3-py3-none-any.whl", hash = "sha256:5008ac581bebf1f6fa0520404261844a231e5715fdbddd10ca73916a3af48ca2", size = 724231, upload-time = "2026-04-05T09:12:48.747Z" },
 ]
 
 [package.optional-dependencies]
@@ -1780,15 +1780,15 @@ wheels = [
 
 [[package]]
 name = "textual-image"
-version = "0.8.5"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/64/e5e49b639794f0ae426f6c19ca541af55b24a30e96df3b03e086688b8ec1/textual_image-0.8.5.tar.gz", hash = "sha256:43d4c0026a4f21fa255f41eac7b0fc1f7410a4c7bc9bf95b908bec901b0a8c3a", size = 109049, upload-time = "2025-12-26T18:38:08.709Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e7/c82ea0604874b6d51d5717a0911061ae5810e36dad2e4d2b11fa7d54cdaa/textual_image-0.12.0.tar.gz", hash = "sha256:fdd0b5ff9c8a99740bc360a99ce014d563fa97d07a5b49b472470809f57c0a74", size = 116403, upload-time = "2026-04-12T17:37:44.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/0d/ca8367c100c09850379f83645abd60f47c051e6b1e7b64adb953bce96be9/textual_image-0.8.5-py3-none-any.whl", hash = "sha256:dffc85458ca8744bce3f17bddbf582b1e086eb52d111f1063753e8dd316fa45d", size = 109618, upload-time = "2025-12-26T18:38:07.11Z" },
+    { url = "https://files.pythonhosted.org/packages/67/2c/38ac586a3834a3bd8cbcf0c8ea1ae23bf68b9cc13b96a67f47a825479dd3/textual_image-0.12.0-py3-none-any.whl", hash = "sha256:0b13f62fe6a29f4ed6dfd641f2779ffe92dde41f16163fa1de69158477aa50aa", size = 115626, upload-time = "2026-04-12T17:37:41.238Z" },
 ]
 
 [[package]]
@@ -1995,18 +1995,18 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.24.1"
+version = "0.24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/6b/20fcc994639fbf5ecc34006b4238ce8be287fc20f5b6f2772a1918d8a7d7/tree_sitter_rust-0.24.1.tar.gz", hash = "sha256:ed8a2f71ac2cb859d2201efb124f04a53bf9c7aa105ef4962fe3e3ba74ea2af9", size = 338854, upload-time = "2026-03-19T17:20:25.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/87/75cbd22b927267d310f76cca1ab3c1d9d41035dfa3eb9cc95f96ee199440/tree_sitter_rust-0.24.2.tar.gz", hash = "sha256:54fb02a5911e345308b405174465112479f56dc39e3f1e7744d7568595f00db9", size = 339341, upload-time = "2026-03-27T21:08:55.629Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/c2/a1a9817ac58cebfbf2e3f0c28952c7d902d1accb652bd4da8b900dad4be4/tree_sitter_rust-0.24.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aa99841370343fd5a28e2b4fc8b794da2323bc12ef6a1888f2d160c766e188a9", size = 130439, upload-time = "2026-03-19T17:20:15.036Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/9b45c2f4b72dc022df7016a0395aea2b7a5575611401786f60a01d803292/tree_sitter_rust-0.24.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:76d726c56f0a249c2b570e37dbb7bbeec7fb50a3969b824d8bde2fd3cddc3715", size = 137723, upload-time = "2026-03-19T17:20:16.634Z" },
-    { url = "https://files.pythonhosted.org/packages/19/3a/86417abd899f4fb465b7e5abc25f0fc5fac11dfdbbb8f2d7f63825fa521c/tree_sitter_rust-0.24.1-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:916cc9c29176790d03f03a58135ca28b5f07e9cb11f5c4d2436ef9b2162b6e38", size = 165734, upload-time = "2026-03-19T17:20:17.841Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/05/3afa2fb2f39375a56ae95ff732d50831eeb756f47e6e143fcdadf3fe99f2/tree_sitter_rust-0.24.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e464ca5bc0228c2bc82e851a2f0e2b008cd98b0520c751ff94f0e9ca30072eb", size = 171389, upload-time = "2026-03-19T17:20:19.103Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/e3/1183ff4af2e21df905378c6e1b9d7d8d44f830d99d3725b8be38d760983e/tree_sitter_rust-0.24.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4e2bca06ebc60c3f10b0a9481752eb54364d3d9896beb5c9d6911f8b87c024b3", size = 169931, upload-time = "2026-03-19T17:20:20.418Z" },
-    { url = "https://files.pythonhosted.org/packages/02/55/d66270ede3a572c88d8c5169c14cb5a5ef1d5ee41fb73fe3beb16ed68107/tree_sitter_rust-0.24.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5def913248e9f2b0bf4d402b281cdfcecaad09a60ca3541ff49901fc9195b0ee", size = 163411, upload-time = "2026-03-19T17:20:21.549Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/49/94a55f2c2fa397a760bbe17eb7df38043545ff7ed7b6b1555d01ea8a3693/tree_sitter_rust-0.24.1-cp39-abi3-win_amd64.whl", hash = "sha256:78c72c85d88496a702c86610dadfed0af014d508134ca66896b2ea0baf7557eb", size = 130685, upload-time = "2026-03-19T17:20:23.544Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/08/269f090dced916f032bc84e6ba7474f56f2b33a96acc38e435f307adc1c0/tree_sitter_rust-0.24.1-cp39-abi3-win_arm64.whl", hash = "sha256:4a89771a0463dcefd8c1850eeab82185e0b22aaf4dde14ba56b138c400438622", size = 129316, upload-time = "2026-03-19T17:20:24.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/24/2b2d33af5e27c84a4fde4e8cd2594bb4ab1e1cf48756a9f40dadc84956cc/tree_sitter_rust-0.24.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3620cfd12340efa43082d45df76349ff511893a9c361da2f8d6d51e307020a59", size = 129507, upload-time = "2026-03-27T21:08:47.585Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2a/cf39f881a545360b5a86bb1accba1f4acc713daab01fb9edd35b6e84f473/tree_sitter_rust-0.24.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:01a46622735498493f29f3e628a90de95c96a07bfbeb88996243eb986b1cee36", size = 136812, upload-time = "2026-03-27T21:08:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/45/a051bbd3045a61182dde25b93ae9a33d2677c935b16952283e12eaf46051/tree_sitter_rust-0.24.2-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e033c5a93b57c88e0a835880de39fc802909ff69f57aaff6000211c196ea5190", size = 164706, upload-time = "2026-03-27T21:08:49.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f6/a5a146df5c0a5daea3ffcd5d7245775fe7f084357770d5a313dd6245ae78/tree_sitter_rust-0.24.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d76d1208c3638b871236090759dfc13d478921320653a6c9da5336e7c58f65a", size = 170310, upload-time = "2026-03-27T21:08:50.424Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a8/f85b1ca75e01361ca5f92d226593ca4857cea49551b9f6c8fa6fc08ea917/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87930163a462408c49ab62c667e74029bc26b4cc7123dd1bdc7352215786c64a", size = 168668, upload-time = "2026-03-27T21:08:51.404Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e1/3519f866a4679ca36acd9f5a06a779ecb8a92b18887c5546458d521df557/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:da2b86099028fd42c6cd32878b7b16b01f8aac0f7b0e98742b7fa6bc3cf09b89", size = 162403, upload-time = "2026-03-27T21:08:52.588Z" },
+    { url = "https://files.pythonhosted.org/packages/34/71/7ef609894dbfe5699eb16f7471f9b8af1d958d8ba3e29c238d7607e8cb47/tree_sitter_rust-0.24.2-cp39-abi3-win_amd64.whl", hash = "sha256:4529c125d928882ddfb879fdc6bc0704913261ecc078b6fa7902559e0daf200d", size = 129422, upload-time = "2026-03-27T21:08:54.031Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d8/050a781172745bc345f98abb7c56e72022ea0790f8e793de981c83c2ef15/tree_sitter_rust-0.24.2-cp39-abi3-win_arm64.whl", hash = "sha256:66ba90f61bd54f4c4f5d30434957daf64507c16b0313df76becb37d63f70a227", size = 128245, upload-time = "2026-03-27T21:08:54.803Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
After the user deletes a work item from the search results we need to remove the entry from the search results table. In addition, if the item deleted is the one currently selected, i.e. its details/data are displayed in the right-hand side panes then the data in these panes needs to be cleared. The pagination details in the border subtitle should also be updated.

This PR also updates `textual` to the latest version and other outdated dependencies.