### PR TITLE
[JT-24] generate labels widget dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for updating the reporter of a work item.
 - Support for fields with `type:number` when we create new work items. By @whyisdifficult in https://github.com/whyisdifficult/jiratui/pull/203
 - Update the search results table after deleting a work item; by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/205
+- Generate a `LabelsWidget` dynamically rather than defining the widget statically at compose time when the user is updating/editing a work item. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/229
+- Update the `required` state of the parent field's widget based. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/229
 
 ### Changed
 

--- a/src/jiratui/widgets/commons/widgets.py
+++ b/src/jiratui/widgets/commons/widgets.py
@@ -778,7 +778,11 @@ class LabelsWidget(Input):
             return []
 
         # split by comma, strip whitespace, remove internal spaces, filter empty strings
-        return [label.strip().replace(' ', '') for label in self.value.split(',') if label.strip()]
+        return [
+            label.strip().replace(' ', '')
+            for label in self.value.split(',')
+            if label.strip() and label.strip() != '-'
+        ]
 
     def get_value_for_update(self) -> list[str]:
         """Returns labels formatted for Jira API update requests (UPDATE mode).
@@ -794,8 +798,12 @@ class LabelsWidget(Input):
         if not self.value or not self.value.strip():
             return []
 
-        # Split by comma, strip whitespace, remove internal spaces, filter empty strings
-        return [label.strip().replace(' ', '') for label in self.value.split(',') if label.strip()]
+        # split by comma, strip whitespace, remove internal spaces, filter empty strings
+        return [
+            label.strip().replace(' ', '')
+            for label in self.value.split(',')
+            if label.strip() and label.strip() != '-'
+        ]
 
     @property
     def value_has_changed(self) -> bool:

--- a/src/jiratui/widgets/work_item_details/details.py
+++ b/src/jiratui/widgets/work_item_details/details.py
@@ -46,7 +46,6 @@ from jiratui.widgets.work_item_details.fields import (
     TimeTrackingWidget,
     WorkItemDetailsDueDate,
     WorkItemFlagField,
-    WorkItemLabelsField,
 )
 from jiratui.widgets.work_item_details.flag_work_item import FlagWorkItemScreen
 from jiratui.widgets.work_item_details.work_log import (
@@ -86,7 +85,6 @@ class IssueDetailsWidget(Vertical):
     - Due Date
     - Resolved
     - Resolution
-    - Labels
 
     Dynamic widgets are composed dynamically based on the work item's edit metadata and the configuration of the
     application, via the variables `enable_updating_additional_fields` and `update_additional_fields_ignore_ids`.
@@ -222,10 +220,6 @@ class IssueDetailsWidget(Vertical):
         return self.query_one(TimeTrackingWidget)
 
     @property
-    def work_item_labels_widget(self) -> WorkItemLabelsField:
-        return self.query_one(WorkItemLabelsField)
-
-    @property
     def issue_resolution_date_field(self) -> ReadOnlyTextField:
         return self.query_one('#issue_resolution_date', expect_type=ReadOnlyTextField)
 
@@ -306,7 +300,7 @@ class IssueDetailsWidget(Vertical):
                     extra_classes='cols-2',
                 )
                 # set widgets in row 9 - cols 3
-                yield WorkItemLabelsField()
+                # yield WorkItemLabelsField()
                 yield HorizontalGroup(id='time-tracking-container', classes='cols-3')
             yield DynamicFieldsWidgets()
 
@@ -324,13 +318,7 @@ class IssueDetailsWidget(Vertical):
             self.app.api,  # type:ignore[attr-defined]
             id='details-reporter-autocomplete',
         ).add_class(*['cols-3'])
-        labels_autocomplete = LabelsAutoComplete(
-            self.work_item_labels_widget,
-            self.app.api,  # type:ignore[attr-defined]
-            required=False,
-            title='Labels',
-        )
-        self.mount_all([assignee_autocomplete, reporter_autocomplete, labels_autocomplete])
+        self.mount_all([assignee_autocomplete, reporter_autocomplete])
 
     async def _search_and_filter_assignees(self, query: str) -> APIControllerResponse:
         # searches and filters users that can be assignees of the work item being edited
@@ -579,7 +567,6 @@ class IssueDetailsWidget(Vertical):
             self.priority_selector.clear()
             self.priority_selector.update_enabled = True
             self.issue_due_date_field.set_original_value(None)
-            self.work_item_labels_widget.clear()
             self._work_item_is_flagged = None
             self._issue_supports_flagging = True
             self.work_item_flag_widget.show = False
@@ -604,13 +591,17 @@ class IssueDetailsWidget(Vertical):
     def _build_payload_for_update(self) -> dict | None:
         """Builds the payload needed for updating the work item.
 
+        This extracts the values of both types of widgets in the update form, those defined statically and those added
+        dynamically.
+
         Returns:
             A dictionary with the values for every Jira field that wil need to be updated for the given work item. The
             key of every entry in the dictionary is the value of the `key` attribute found in the field's edit-metadata.
         """
 
-        # maps field id to field value
+        # the keys of this dictionary are the value of the fields' key attribute (as found in the edit metadata)
         payload: dict[str, Any] = {}
+
         # process the "static" fields
         if self.issue_summary_field.update_enabled:
             # check if the summary is not empty and has changed
@@ -672,24 +663,6 @@ class IssueDetailsWidget(Vertical):
                     title='Update Work Item',
                 )
                 return None
-
-        if self.work_item_labels_widget.update_enabled:
-            # update the issue's labels - strip whitespace and remove internal spaces
-            labels: list[str] = (
-                [
-                    label.strip().replace(' ', '')
-                    for label in self.work_item_labels_widget.value.split(',')
-                    if label.strip() and label.strip() != '-'
-                ]
-                if self.work_item_labels_widget.value
-                else []
-            )
-
-            current_labels: list[str] = list(self.issue.labels or [])
-            # case-insensitive comparison, but preserve original case
-            if {lbl.lower() for lbl in labels} != {lbl.lower() for lbl in current_labels}:
-                # update the list of labels (empty list will remove all labels)
-                payload[self.work_item_labels_widget.jira_field_key] = labels
 
         # process dynamically-generated field widgets; e.g. additional system fields and custom fields
         if CONFIGURATION.get().enable_updating_additional_fields:
@@ -798,7 +771,7 @@ class IssueDetailsWidget(Vertical):
             await self._refresh_work_item_details()
 
     @staticmethod
-    def _determine_editable_fields(work_item: JiraIssue) -> dict:
+    def _extract_editable_and_required_fields(work_item: JiraIssue) -> dict:
         """Determines which of the fields of a work item that can be updated via the details form support updates
         based on the work item's edit metadata.
 
@@ -820,19 +793,17 @@ class IssueDetailsWidget(Vertical):
         # if a field does not have edit metadata then we assume we can not edit its value
         # the key of this dictionary is the value of the `key` attribute found in the field's edit-metadata
         editable_fields: dict[str, bool] = {}
+        required_fields: dict[str, bool] = {}
 
         if field_summary := fields.get('summary', {}):
             editable_fields[field_summary.get('key')] = 'set' in field_summary.get('operations', {})
+            required_fields[field_summary.get('key')] = field_summary.get('required', False)
 
         if field_due_date := fields.get('duedate', {}):
             editable_fields[field_due_date.get('key')] = 'set' in field_due_date.get(
                 'operations', {}
             )
-
-        if field_priority := fields.get('priority', {}):
-            editable_fields[field_priority.get('key')] = 'set' in field_priority.get(
-                'operations', {}
-            )
+            required_fields[field_due_date.get('key')] = field_due_date.get('required', False)
 
         if field_parent := fields.get('parent', {}):
             if work_item.issue_type.hierarchy_level == 1:
@@ -843,31 +814,24 @@ class IssueDetailsWidget(Vertical):
                 editable_fields[field_parent.get('key')] = 'set' in field_parent.get(
                     'operations', {}
                 )
+            required_fields[field_parent.get('key')] = field_parent.get('required', False)
 
         if field_assignee := fields.get('assignee', {}):
             editable_fields[field_assignee.get('key')] = 'set' in field_assignee.get(
                 'operations', {}
             )
+            required_fields[field_assignee.get('key')] = field_assignee.get('required', False)
 
         if field_reporter := fields.get('reporter', {}):
             editable_fields[field_reporter.get('key')] = 'set' in field_reporter.get(
                 'operations', {}
             )
+            required_fields[field_reporter.get('key')] = field_reporter.get('required', False)
 
-        if field_labels := fields.get('labels', {}):
-            editable_fields[field_labels.get('key')] = 'set' in field_labels.get('operations', {})
-
-        if field_components := fields.get('components', {}):
-            editable_fields[field_components.get('key')] = 'set' in field_components.get(
-                'operations', {}
-            )
-
-        # include custom fields (fields starting with 'customfield_')
-        for field_id, field_meta in fields.items():
-            if field_id.startswith('customfield_') and field_id not in editable_fields:
-                editable_fields[field_meta.get('key')] = 'set' in field_meta.get('operations', {})
-
-        return editable_fields
+        return {
+            'editable_fields': editable_fields,
+            'required_fields': required_fields,
+        }
 
     async def _retrieve_applicable_status_codes(
         self,
@@ -925,7 +889,9 @@ class IssueDetailsWidget(Vertical):
 
         # check which of the fields in the details form can be updated; disable the widgets of those that do not support
         # updates
-        editable_fields: dict = self._determine_editable_fields(work_item)
+        editable_and_required_fields: dict = self._extract_editable_and_required_fields(work_item)
+        editable_fields = editable_and_required_fields.get('editable_fields', {})
+        required_fields = editable_and_required_fields.get('required_fields', {})
 
         # set the assignee field
         if work_item_assignee := work_item.assignee:
@@ -969,6 +935,9 @@ class IssueDetailsWidget(Vertical):
         self.issue_parent_field.update_enabled = editable_fields.get(
             self.issue_parent_field.jira_field_key
         )
+        self.issue_parent_field.jira_field_is_required = required_fields.get(
+            self.issue_parent_field.jira_field_key
+        )
         self.issue_sprint_field.value = work_item.sprint_name
         self.issue_summary_field.value = work_item.summary
         self.issue_summary_field.update_enabled = editable_fields.get(
@@ -983,12 +952,6 @@ class IssueDetailsWidget(Vertical):
         self._setup_priority_selector(work_item.edit_meta, work_item.priority)
         # set up time tracking widgets
         self._setup_time_tracking(work_item.time_tracking)
-        # set up the labels; if any exists
-        if work_item.labels:
-            self.work_item_labels_widget.value = ','.join(work_item.labels)
-        self.work_item_labels_widget.update_enabled = editable_fields.get(
-            self.work_item_labels_widget.jira_field_key
-        )
         # check if the work item has been flagged; and show a label at the top with a message for the user
         self.run_worker(self._determine_issue_flagged_status(work_item))
 
@@ -1038,9 +1001,13 @@ class IssueDetailsWidget(Vertical):
                 await self.dynamic_fields_widgets_container.mount(
                     MultiUserPickerAutoComplete(target=widget, api_controller=self.app.api)  # type:ignore
                 )
-            for w in self.dynamic_fields_widgets_container.query(SingleUserPickerWidget):
+            for widget in self.dynamic_fields_widgets_container.query(SingleUserPickerWidget):  # type:ignore[assignment]
                 await self.dynamic_fields_widgets_container.mount(
-                    UsersAutoComplete(target=w, api_controller=self.app.api)  # type:ignore
+                    UsersAutoComplete(target=widget, api_controller=self.app.api)  # type:ignore
+                )
+            for widget in self.dynamic_fields_widgets_container.query(LabelsWidget):  # type:ignore[assignment]
+                await self.dynamic_fields_widgets_container.mount(
+                    LabelsAutoComplete(target=widget, api_controller=self.app.api)  # type:ignore
                 )
 
     async def _determine_issue_flagged_status(self, issue: JiraIssue) -> None:

--- a/src/jiratui/widgets/work_item_details/factory.py
+++ b/src/jiratui/widgets/work_item_details/factory.py
@@ -14,7 +14,6 @@ class WorkItemManualUpdateFieldKeys(Enum):
     """These fields are excluded from the dynamic updates because they are already part of the details tab's form or,
     they are updated separately."""
 
-    LABELS = 'labels'
     COMMENT = 'comment'
     DUE_DATE = 'duedate'
     ISSUE_LINKS = 'issuelinks'
@@ -31,7 +30,6 @@ class WorkItemManualUpdateFieldNames(Enum):
     """These fields are excluded from the dynamic updates because they are already part of the details tab's form or,
     they are updated separately."""
 
-    LABELS = 'labels'
     COMMENT = 'comment'
     DUE_DATE = 'duedate'
     ISSUE_LINKS = 'issuelinks'
@@ -304,7 +302,14 @@ def create_dynamic_widgets_for_updating_work_item(
                     )
         else:
             # process the non-custom fields based on the schema type
-            if schema.get('type', '').lower() == 'number':
+            if schema.get('system', '').lower() == 'labels':
+                # get the current value of the field
+                if (value := work_item.labels) is None:
+                    value = []
+                widget = builder.build_labels(
+                    mode=FieldMode.UPDATE, metadata=metadata, current_value=value
+                )
+            elif schema.get('type', '').lower() == 'number':
                 if __field_id in work_item.get_additional_fields():
                     # get the current value of the field from the issue's additional fields
                     value = work_item.get_additional_field_value(__field_id)

--- a/src/jiratui/widgets/work_item_details/fields.py
+++ b/src/jiratui/widgets/work_item_details/fields.py
@@ -102,6 +102,7 @@ class IssueParentField(Input):
     """
 
     update_enabled: Reactive[bool | None] = reactive(True)
+    jira_field_is_required: Reactive[bool | None] = reactive(True)
 
     def __init__(self):
         super().__init__()
@@ -116,6 +117,9 @@ class IssueParentField(Input):
         self.update_is_enabled = enabled
         self.disabled = not enabled
 
+    def watch_jira_field_is_required(self, required: bool) -> None:
+        self._update_required_status(required)
+
     @on(Input.Blurred)
     def clean_value(self, event: Input.Blurred) -> None:
         if event.value is not None:
@@ -125,17 +129,13 @@ class IssueParentField(Input):
         if event.value:
             self.value = event.value.strip()
 
-    def update_required_status(self, required: bool) -> None:
+    def _update_required_status(self, required: bool) -> None:
         if required:
             self.border_subtitle = '(*)'
             self.add_class('required')
         else:
             self.border_subtitle = None
             self.remove_class('required')
-
-    def clear(self) -> None:
-        super().clear()
-        self.update_required_status(False)
 
 
 class IssueSummaryField(Input):
@@ -188,32 +188,6 @@ class WorkItemFlagField(Label):
             self.styles.display = 'block'
         else:
             self.styles.display = 'none'
-
-
-class WorkItemLabelsField(Input):
-    """A widget to display and update the labels field of a work item.
-
-    This widget is part of widgets defined statically in the form that allows users to update a work item.
-    """
-
-    update_enabled: Reactive[bool | None] = reactive(True)
-
-    def __init__(self):
-        super().__init__()
-        self.border_title = 'Labels'
-        self.add_class(*['create-update-field-widget', 'cols-3'])
-        self.jira_field_key = 'labels'
-        """The id used by Jira to identify this field in the edit-metadata."""
-        self.update_is_enabled = True
-        """Indicates whether the work item allows editing/updating this field."""
-
-    def on_input_changed(self, event: Input.Changed) -> None:
-        # Allow spaces in labels - no longer converting to dashes
-        pass
-
-    def watch_update_enabled(self, enabled: bool = True) -> None:
-        self.update_is_enabled = enabled
-        self.disabled = not enabled
 
 
 class IssueTypeField(ReadOnlyField):

--- a/src/jiratui/widgets/work_item_details/tests/test_issue_details_widget.py
+++ b/src/jiratui/widgets/work_item_details/tests/test_issue_details_widget.py
@@ -26,6 +26,7 @@ from jiratui.widgets.commons.base import MultiUserPickerAutoComplete
 from jiratui.widgets.commons.users import JiraUserInput, UsersAutoComplete
 from jiratui.widgets.commons.widgets import (
     DateInputWidget,
+    LabelsWidget,
     MultiUserPickerWidget,
     NumericInputWidget,
     SingleUserPickerWidget,
@@ -341,7 +342,7 @@ async def test_determine_editable_fields_without_edit_metadata(
         await pilot.pause()
 
         # WHEN
-        result = details_widget._determine_editable_fields(jira_issue)
+        result = details_widget._extract_editable_and_required_fields(jira_issue)
         # THEN
         assert result == {}
 
@@ -354,17 +355,23 @@ async def test_determine_editable_fields(jira_issue, app: JiraApp):
         await app.mount(details_widget)
         await pilot.pause()
         # WHEN
-        result = details_widget._determine_editable_fields(jira_issue)
+        result = details_widget._extract_editable_and_required_fields(jira_issue)
         # THEN
         assert result == {
-            'summary': True,
-            'assignee': True,
-            'priority': True,
-            'customfield_10021': True,
-            'parent': True,
-            'duedate': True,
-            'reporter': True,
-            'labels': True,
+            'editable_fields': {
+                'summary': True,
+                'assignee': True,
+                'parent': True,
+                'duedate': True,
+                'reporter': True,
+            },
+            'required_fields': {
+                'summary': True,
+                'assignee': False,
+                'parent': False,
+                'duedate': False,
+                'reporter': True,
+            },
         }
 
 
@@ -377,9 +384,9 @@ async def test_determine_editable_fields_item_without_parent(jira_issue, app: Ji
         await app.mount(details_widget)
         await pilot.pause()
         # WHEN
-        result = details_widget._determine_editable_fields(jira_issue)
+        result = details_widget._extract_editable_and_required_fields(jira_issue)
         # THEN
-        assert result['parent'] is False
+        assert result['editable_fields']['parent'] is False
 
 
 @pytest.mark.asyncio
@@ -391,9 +398,9 @@ async def test_determine_editable_fields_item_with_possible_parent(jira_issue, a
         await app.mount(details_widget)
         await pilot.pause()
         # WHEN
-        result = details_widget._determine_editable_fields(jira_issue)
+        result = details_widget._extract_editable_and_required_fields(jira_issue)
         # THEN
-        assert result['parent'] is True
+        assert result['editable_fields']['parent'] is True
 
 
 @patch.object(APIController, 'get_project_statuses')
@@ -456,7 +463,6 @@ async def test_build_payload_for_update_nothing_to_update(app: JiraApp):
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         # WHEN
         payload = details_widget._build_payload_for_update()
         # THEN
@@ -479,7 +485,6 @@ async def test_build_payload_for_update_nothing_to_update_update_additional_fiel
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -507,7 +512,6 @@ async def test_build_payload_for_update_with_summary_changed(
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         # WHEN
         payload = details_widget._build_payload_for_update()
         # THEN
@@ -531,7 +535,6 @@ async def test_build_payload_for_update_with_summary_unchanged(issue_mock: Mock,
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         # WHEN
         payload = details_widget._build_payload_for_update()
         # THEN
@@ -553,7 +556,6 @@ async def test_build_payload_for_update_with_duedate_unchanged(app: JiraApp):
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -578,7 +580,6 @@ async def test_build_payload_for_update_with_duedate_changed(app: JiraApp):
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -605,7 +606,6 @@ async def test_build_payload_for_update_with_priority_unchanged(
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -633,7 +633,6 @@ async def test_build_payload_for_update_with_priority_changed_without_priority_s
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -662,7 +661,6 @@ async def test_build_payload_for_update_with_priority_changed_with_priority_sele
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -690,7 +688,6 @@ async def test_build_payload_for_update_with_parent_unchanged(
         details_widget.issue_parent_field.value = 'P2'
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -718,7 +715,6 @@ async def test_build_payload_for_update_with_parent_changed(
         details_widget.issue_parent_field.value = 'WI-1'
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -746,7 +742,6 @@ async def test_build_payload_for_update_with_assignee_unchanged(
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = True
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -774,7 +769,6 @@ async def test_build_payload_for_update_with_assignee_changed(
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = True
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -802,7 +796,6 @@ async def test_build_payload_for_update_with_reporter_changed(
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = True
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -831,7 +824,6 @@ async def test_build_payload_for_update_with_reporter_missing(
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = True
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -859,7 +851,6 @@ async def test_build_payload_for_update_with_reporter_unchanged(
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = True
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
 
         # WHEN
@@ -869,17 +860,11 @@ async def test_build_payload_for_update_with_reporter_unchanged(
         assert payload == {}
 
 
-@pytest.mark.parametrize(
-    'labels, expected_labels',
-    [
-        ('test1,test2', ['test1', 'test2']),
-        ('test2', ['test2']),
-    ],
-)
-@patch.object(IssueDetailsWidget, 'issue')
+# TODO
+@patch.object(LabelsWidget, 'value_has_changed', PropertyMock(return_value=False))
 @pytest.mark.asyncio
-async def test_build_payload_for_update_with_labels_changed(
-    issue_mock: Mock, labels, expected_labels, jira_issue, app: JiraApp
+async def test_build_payload_for_update_update_additional_fields_enabled_labels_field_value_unchanged(
+    app: JiraApp,
 ):
     # GIVEN
     app.config.enable_updating_additional_fields = True
@@ -887,35 +872,32 @@ async def test_build_payload_for_update_with_labels_changed(
         details_widget = IssueDetailsWidget()
         await app.mount(details_widget)
         await pilot.pause()
-        issue_mock.configure_mock(labels=['test1'])
         details_widget.issue_summary_field.update_enabled = False
         details_widget.issue_due_date_field.update_enabled = False
         details_widget.priority_selector.update_enabled = False
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = True
-        details_widget.work_item_labels_widget.value = labels
         await details_widget.dynamic_fields_widgets_container.remove_children()
+        await details_widget.dynamic_fields_widgets_container.mount(
+            LabelsWidget(
+                mode=FieldMode.UPDATE, field_id='a', jira_field_key='a', original_value=['label1']
+            )
+        )
 
         # WHEN
-        payload = details_widget._build_payload_for_update()
-        # THEN
-        assert payload == {'labels': expected_labels}
+        with patch.object(LabelsWidget, 'get_value_for_update') as m:
+            m.return_value = ['label1']
+            payload = details_widget._build_payload_for_update()
+            # THEN
+            assert payload == {}
 
 
-@pytest.mark.parametrize(
-    'new_labels, current_labels',
-    [
-        ('test1,test2', ['test1', 'test2']),
-        ('Test2', ['test2']),
-        ('Test2, test3 ', ['test2', 'test3']),
-    ],
-)
-@patch.object(IssueDetailsWidget, 'issue')
+# TODO
+@patch.object(LabelsWidget, 'value_has_changed', PropertyMock(return_value=True))
 @pytest.mark.asyncio
-async def test_build_payload_for_update_with_labels_unchanged(
-    issue_mock: Mock, new_labels, current_labels, jira_issue, app: JiraApp
+async def test_build_payload_for_update_update_additional_fields_enabled_labels_field_value_changed(
+    app: JiraApp,
 ):
     # GIVEN
     app.config.enable_updating_additional_fields = True
@@ -923,21 +905,28 @@ async def test_build_payload_for_update_with_labels_unchanged(
         details_widget = IssueDetailsWidget()
         await app.mount(details_widget)
         await pilot.pause()
-        issue_mock.configure_mock(labels=current_labels)
         details_widget.issue_summary_field.update_enabled = False
         details_widget.issue_due_date_field.update_enabled = False
         details_widget.priority_selector.update_enabled = False
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = True
-        details_widget.work_item_labels_widget.value = new_labels
         await details_widget.dynamic_fields_widgets_container.remove_children()
+        await details_widget.dynamic_fields_widgets_container.mount(
+            LabelsWidget(
+                mode=FieldMode.UPDATE,
+                field_id='field_a',
+                jira_field_key='field_a',
+                original_value=['label1'],
+            )
+        )
 
         # WHEN
-        payload = details_widget._build_payload_for_update()
-        # THEN
-        assert payload == {}
+        with patch.object(LabelsWidget, 'get_value_for_update') as m:
+            m.return_value = ['label1', 'label2']
+            payload = details_widget._build_payload_for_update()
+            # THEN
+            assert payload == {'field_a': ['label1', 'label2']}
 
 
 @patch.object(NumericInputWidget, 'value_has_changed', PropertyMock(return_value=False))
@@ -957,7 +946,6 @@ async def test_build_payload_for_update_update_additional_fields_enabled_numeric
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
         await details_widget.dynamic_fields_widgets_container.mount(
             NumericInputWidget(mode=FieldMode.UPDATE, field_id='a', jira_field_key='a')
@@ -986,7 +974,6 @@ async def test_build_payload_for_update_update_additional_fields_enabled_numeric
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
         await details_widget.dynamic_fields_widgets_container.mount(
             NumericInputWidget(mode=FieldMode.UPDATE, field_id='field_a', jira_field_key='field_a')
@@ -1017,7 +1004,6 @@ async def test_build_payload_for_update_update_additional_fields_enabled_numeric
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
         await details_widget.dynamic_fields_widgets_container.mount(
             NumericInputWidget(mode=FieldMode.UPDATE, field_id='field_a', jira_field_key='field_a')
@@ -1051,7 +1037,6 @@ async def test_build_payload_for_update_update_additional_fields_enabled_non_num
         details_widget.issue_parent_field.update_enabled = False
         details_widget.assignee_selector.update_enabled = False
         details_widget.reporter_selector.update_enabled = False
-        details_widget.work_item_labels_widget.update_enabled = False
         await details_widget.dynamic_fields_widgets_container.remove_children()
         await details_widget.dynamic_fields_widgets_container.mount(
             DateInputWidget(mode=FieldMode.UPDATE, field_id='field_a', jira_field_key='field_a')
@@ -1114,7 +1099,6 @@ async def test_clear_form(app: JiraApp):
         assert details_widget.priority_selector.selection is None
         assert details_widget.priority_selector.update_enabled is True
         assert details_widget.issue_due_date_field.original_value is None
-        assert details_widget.work_item_labels_widget.value == ''
         assert details_widget._work_item_is_flagged is None
         assert details_widget._issue_supports_flagging is True
         assert details_widget.work_item_flag_widget.show is False
@@ -1356,12 +1340,12 @@ async def test_watch_issue(jira_issue, app: JiraApp):
 @patch.object(IssueDetailsWidget, '_setup_time_tracking')
 @patch.object(IssueDetailsWidget, '_add_dynamic_widgets')
 @patch.object(IssueDetailsWidget, '_determine_issue_flagged_status')
-@patch.object(IssueDetailsWidget, '_determine_editable_fields')
+@patch.object(IssueDetailsWidget, '_extract_editable_and_required_fields')
 @patch.object(APIController, 'get_project_statuses')
 @pytest.mark.asyncio
 async def test_watch_issue_with_valid_issue(
     get_project_statuses_mock: AsyncMock,
-    determine_editable_fields_mock: Mock,
+    extract_editable_and_required_fields_mock: Mock,
     determine_issue_flagged_status_mock: Mock,
     add_dynamic_widgets_mock: Mock,
     setup_time_tracking_mock: Mock,
@@ -1377,19 +1361,21 @@ async def test_watch_issue_with_valid_issue(
         get_project_statuses_mock.return_value = APIControllerResponse(
             result={'2': {'issue_type_statuses': [IssueStatus(id='3', name='Done')]}}
         )
-        determine_editable_fields_mock.return_value = {
-            'assignee': True,
-            'reporter': True,
-            'parent': True,
-            'summary': True,
-            'duedate': True,
+        extract_editable_and_required_fields_mock.return_value = {
+            'editable_fields': {
+                'assignee': True,
+                'reporter': True,
+                'parent': True,
+                'summary': True,
+                'duedate': True,
+            }
         }
         # WHEN
         details_widget.watch_issue(jira_issue)
         await pilot.pause()
         # THEN
         get_project_statuses_mock.assert_called_once_with('P1')
-        determine_editable_fields_mock.assert_called_once()
+        extract_editable_and_required_fields_mock.assert_called_once()
         assert details_widget.assignee_selector.account_id == '2'
         assert details_widget.assignee_selector.update_enabled is True
         assert details_widget.reporter_selector.account_id == '1'
@@ -1408,7 +1394,6 @@ async def test_watch_issue_with_valid_issue(
         assert details_widget.issue_summary_field.update_enabled is True
         assert details_widget.issue_due_date_field.value == '2025-10-12'
         assert details_widget.issue_due_date_field.update_enabled is True
-        assert details_widget.work_item_labels_widget.value == ''
         assert details_widget.priority_selector.update_enabled is True
         determine_issue_flagged_status_mock.assert_called_once()
         setup_time_tracking_mock.assert_called_once()
@@ -1418,12 +1403,12 @@ async def test_watch_issue_with_valid_issue(
 @patch.object(IssueDetailsWidget, '_setup_time_tracking')
 @patch.object(IssueDetailsWidget, '_add_dynamic_widgets')
 @patch.object(IssueDetailsWidget, '_determine_issue_flagged_status')
-@patch.object(IssueDetailsWidget, '_determine_editable_fields')
+@patch.object(IssueDetailsWidget, '_extract_editable_and_required_fields')
 @patch.object(APIController, 'get_project_statuses')
 @pytest.mark.asyncio
 async def test_watch_issue_with_valid_issue_alternative_values(
     get_project_statuses_mock: AsyncMock,
-    determine_editable_fields_mock: Mock,
+    extract_editable_and_required_fields_mock: Mock,
     determine_issue_flagged_status_mock: Mock,
     add_dynamic_widgets_mock: Mock,
     setup_time_tracking_mock: Mock,
@@ -1439,12 +1424,14 @@ async def test_watch_issue_with_valid_issue_alternative_values(
         get_project_statuses_mock.return_value = APIControllerResponse(
             result={'2': {'issue_type_statuses': [IssueStatus(id='3', name='Done')]}}
         )
-        determine_editable_fields_mock.return_value = {
-            'assignee': True,
-            'reporter': True,
-            'parent': True,
-            'summary': True,
-            'duedate': True,
+        extract_editable_and_required_fields_mock.return_value = {
+            'editable_fields': {
+                'assignee': True,
+                'reporter': True,
+                'parent': True,
+                'summary': True,
+                'duedate': True,
+            }
         }
         jira_issue.assignee = None
         jira_issue.reporter = None
@@ -1456,7 +1443,7 @@ async def test_watch_issue_with_valid_issue_alternative_values(
         await pilot.pause()
         # THEN
         get_project_statuses_mock.assert_called_once_with('P1')
-        determine_editable_fields_mock.assert_called_once()
+        extract_editable_and_required_fields_mock.assert_called_once()
         assert details_widget.assignee_selector.account_id is None
         assert details_widget.assignee_selector.update_enabled is True
         assert details_widget.reporter_selector.account_id is None
@@ -1545,7 +1532,6 @@ async def test_static_widgets_css_classes(jira_issue, app: JiraApp):
         assert 'create-update-field-widget' in details_widget.issue_resolution_date_field.classes
         assert 'input-date' in details_widget.issue_resolution_date_field.classes
         assert 'create-update-field-widget' in details_widget.issue_resolution_field.classes
-        assert 'create-update-field-widget' in details_widget.work_item_labels_widget.classes
 
 
 @patch.object(IssueDetailsWidget, 'issue')

--- a/src/jiratui/widgets/work_item_details/tests/test_widgets_factory.py
+++ b/src/jiratui/widgets/work_item_details/tests/test_widgets_factory.py
@@ -81,7 +81,6 @@ def test_create_dynamic_widgets_without_edit_metadata(work_item: JiraIssue):
 @pytest.mark.parametrize(
     'field_key',
     [
-        'labels',
         'comment',
         'duedate',
         'issuelinks',
@@ -106,7 +105,6 @@ def test_create_dynamic_widgets_skip_static_update_fields(field_key: str, work_i
 @pytest.mark.parametrize(
     'field_name',
     [
-        'Labels',
         'comment',
         'duedate',
         'issuelinks',


### PR DESCRIPTION
This PR updates the details tab:

- generate a `LabelsWidget` dynamically rather than defining the widget statically at compose time
- update the widget used for the parent field to reflect the `required` state of the `parent` field.