### PR TITLE
JT-28: Use tabs to display text-based fields within the Info tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new config variable `enable_updating_rich_text` to enable/disable editing fields that use rich text. The default is `True`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/235
 - Add new config variable `text_editor` to define the preferred command for editing fields that use rich text. The default is to use the system's default editor. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/235
 - Add support for copying the content of textarea-based fields to the clipboard. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/235
+- Add support for editing rich-text based fields when creating new work items. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
 
 ### Changed
 
@@ -33,6 +34,8 @@ autocomplete feature there is no need to fetch all the users anymore.
 cases; by [@vkhitrin](https://github.com/vkhitrin) in https://github.com/whyisdifficult/jiratui/pull/163. This work in this PR
 has been applied in this [PR](https://github.com/whyisdifficult/jiratui/pull/163) to make resolving conflicts more
 manageable. By [@whyisdifficult](https://github.com/whyisdifficult)  in https://github.com/whyisdifficult/jiratui/pull/199
+- Display rich-text based fields in tabs within the Info tab. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- Refactor the UI for adding ew work items. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [1.8.0] - 2026-05-16
 
 ### Added
 
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new config variable `enable_updating_rich_text` to enable/disable editing fields that use rich text. The default is `True`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/235
 - Add new config variable `text_editor` to define the preferred command for editing fields that use rich text. The default is to use the system's default editor. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/235
 - Add support for copying the content of textarea-based fields to the clipboard. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/235
-- Add support for editing rich-text based fields when creating new work items. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- Add support for editing rich-text based fields when creating new work items. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/242
 
 ### Changed
 
@@ -34,8 +34,8 @@ autocomplete feature there is no need to fetch all the users anymore.
 cases; by [@vkhitrin](https://github.com/vkhitrin) in https://github.com/whyisdifficult/jiratui/pull/163. This work in this PR
 has been applied in this [PR](https://github.com/whyisdifficult/jiratui/pull/163) to make resolving conflicts more
 manageable. By [@whyisdifficult](https://github.com/whyisdifficult)  in https://github.com/whyisdifficult/jiratui/pull/199
-- Display rich-text based fields in tabs within the Info tab. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
-- Refactor the UI for adding ew work items. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- Display rich-text based fields in tabs within the Info tab. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/242
+- Refactor the UI for adding ew work items. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/242
 
 ### Bug Fixes
 

--- a/docs/users/usage/index.md
+++ b/docs/users/usage/index.md
@@ -509,17 +509,31 @@ project and a type of work item.
 
 #### Basic Workflow
 
-The modal displays these four required fields:
+The modal displays these fields:
+
+
+The form includes a fixed set of fields and, a set of fields that are dynamically created depending on the project and
+type of work item that you want to create. These fields are always present in the form:
 
 - **Project** (dropdown) – Select which project the work item belongs to
 - **Issue Type** (dropdown) – Choose the type of work item (e.g., Task, Bug, Story)
 - **Reporter** (searchable field) – Enter your name or email; autocomplete filters by display name or email address
 - **Summary** (text field) – Provide a brief description of the work item
-
-In addition to these required fields, the form also includes two optional fields:
-
 - **Assignee** (searchable field) – Specify who will work on the item
-- **Parent Issue** (text field) – Enter the key of a parent issue if this is a sub-task
+- **Parent Key** (text field) – Enter the key of a parent issue if this is a sub-task
+- **Description**: If your Jira instance runs on the cloud and uses API v3 then it supports ADF. In this case you can
+write your description in CommonMark. If you Jira instance runs on your DC or uses API v2 then ADF is not supported
+and the text you provide will be treated as plain text.
+
+When you select a type of issue the form will be updated to include additional fields. These are created dynamically
+based on the create-metadata associated to the type of issue you want to create. These fields are controlled by 2
+configuration variables. See the section below for more details:
+
+- `enable_creating_additional_fields`: this controls whether the form should include dynamic fields or not.
+- `create_additional_fields_ignore_ids`: this controls which dynamic fields to skip. You can specify a list of field ids
+to skip.
+
+*Tip*: when you hover over a field's input widget a tooltip will give you the id of the field.
 
 #### Selecting Projects and Issue Types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jiratui"
-version = "1.7.0"
+version = "1.8.0"
 description = "A TUI for interacting with Atlassian Jira from your terminal."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/jiratui/config.py
+++ b/src/jiratui/config.py
@@ -222,7 +222,8 @@ class ApplicationConfiguration(BaseSettings):
     """Configuration for styling components like work item status, priorities and type colors."""
     enable_updating_rich_text: bool = True
     """Enables/Disable updating fields that use rich text. These are the fields that support Atlassian's ADF. Refer to
-    for more details."""
+    https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#version and
+    https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/ for more details."""
     text_editor: str | None = Field(default=os.getenv('EDITOR'))
     """The command to use for editing text-based fields. The default is the system's default editor. Set it to `None` to
      use a simpler built-in Markdown editor."""

--- a/src/jiratui/conftest.py
+++ b/src/jiratui/conftest.py
@@ -173,6 +173,7 @@ def app() -> JiraApp:
         update_additional_fields_ignore_ids=None,
         enable_creating_additional_fields=False,
         create_additional_fields_ignore_ids=None,
+        styling=None,
     )
     app = JiraApp(config_mock)
     app.api = APIController(config_mock)

--- a/src/jiratui/css/jt.tcss
+++ b/src/jiratui/css/jt.tcss
@@ -159,8 +159,6 @@ IssueCommentsWidget {
    align: left middle;
 }
 
-
-
 .create-update-field-widget {
     box_sizing: content-box;
     height: 1;
@@ -179,10 +177,10 @@ IssueCommentsWidget {
         width: 15;
     }
     &.summary {
-        width: 95%;
+        width: 100%;
     }
     &.parent-key {
-        width: 20;
+        width: 15;
     }
     &.numeric {
         width: 80%;
@@ -669,8 +667,29 @@ CreateWorkItemIssueTypeSelectionInput {
     }
 }
 
-#add-work-item-form {
-    width: 100%;
+.add-work-item-form {
+    box_sizing: border-box;
+
+    margin: 0 0;
+    padding: 0 0;
+    scrollbar-size-vertical: 1;
+}
+.add-work-item-form-textarea-fields {
+    box_sizing: border-box;
+
+    margin: 0 0;
+    padding: 0 0;
+    scrollbar-size-vertical: 1;
+}
+.add-work-item-buttons {
+    height: auto;
+}
+
+.create-work-item-textarea-field-pane {
+    box_sizing: content-box;
+    margin: 0 0;
+    padding: 0 0;
+    height: 1fr;
 }
 
 AddWorkItemScreen {
@@ -678,11 +697,14 @@ AddWorkItemScreen {
     background: $background 80%;
 }
 AddWorkItemScreen > Vertical {
-    width: 70%;
+    width: 95%;
     height: auto;
     border: round $foreground;
     padding: 0 1;
     & > Static {
+        margin-top: 1;
+    }
+    & > Rule {
         margin-top: 1;
     }
 }
@@ -693,6 +715,7 @@ AddWorkItemScreen > Vertical {
     box_sizing: content-box;
     border-top: blank $surface-lighten-1;
     border-bottom: blank $surface-lighten-1;
+    margin: 0 0;
 }
 #add-work-item-button-quit {
     width: 20%;
@@ -700,10 +723,12 @@ AddWorkItemScreen > Vertical {
     box_sizing: content-box;
     border-top: blank $surface-lighten-1;
     border-bottom: blank $surface-lighten-1;
+    margin: 0 0;
 }
 
+/* a grid for the layout of the static fields in the form that creates work items */
 .add-work-item-fields-grid {
-    grid-size: 2 3;
+    grid-size: 2 4;
     grid-columns: 50% 50%;
 }
 
@@ -714,9 +739,9 @@ AddWorkItemScreen > Vertical {
 }
 
 .create-work-item-description {
-    box_sizing: content-box;
-    height: 20%;
-    width: 80%;
+    box_sizing: border-box;
+    height: 100%;
+    width: 100%;
     border: round $primary-lighten-3;
     margin: 0 0;
     padding: 0 1;

--- a/src/jiratui/css/jt.tcss
+++ b/src/jiratui/css/jt.tcss
@@ -1012,7 +1012,7 @@ DisplayTextContentScreen > MarkdownViewer {
     margin-top: 1;
 }
 
-.work-item-info-collapsible {
+.work-item-info-tabs-container {
     scrollbar-size-vertical: 1;
 }
 

--- a/src/jiratui/utils/in_app_help.md
+++ b/src/jiratui/utils/in_app_help.md
@@ -249,6 +249,29 @@ To create a work item you can press `ctrl+n`. This will open up a modal screen w
 fields to create the work item. Fields marked with `(*)` are required. If the item is created successfully a message
 will pop up in the app indicating the work item key.
 
+The form includes a fixed set of fields and, a set of fields that are dynamically created depending on the project and
+type of work item that you want to create. These fields are always present in the form:
+
+- Project
+- Issue Type: this depends on the selected project
+- Reporter
+- Assignee
+- Parent Key: this is only relevant for sub-tasks
+- Summary
+- Description: If your Jira instance runs on the cloud and uses API v3 then it supports ADF. In this case you can
+write your description in CommonMark. If you Jira instance runs on your DC or uses API v2 then ADF is not supported
+and the text you provide will be treated as plain text.
+
+When you select a type of issue the form will be updated to include additional fields. These are created dynamically
+based on the create-metadata associated to the type of issue you want to create. These fields are controlled by 2
+configuration variables:
+
+- `enable_creating_additional_fields`: this controls whether the form should include dynamic fields or not.
+- `create_additional_fields_ignore_ids`: this controls which dynamic fields to skip. You can specify a list of field ids
+to skip.
+
+*Tip*: when you hover over a field's input widget a tooltip will give you the id of the field.
+
 # Updating Work Items
 
 The "Details" tab on the right-hand side shows the details of the currently selected work item. The tab displays a form

--- a/src/jiratui/widgets/commons/adf.py
+++ b/src/jiratui/widgets/commons/adf.py
@@ -1,8 +1,11 @@
 """ADF TextArea Widget - Handles Atlassian Document Format conversion and rendering."""
 
+from dataclasses import dataclass
 import hashlib
 import logging
 
+from textual.binding import Binding
+from textual.message import Message
 from textual.widgets import Markdown, TextArea
 
 from jiratui.utils.adf import convert_adf_to_markdown, convert_markdown_to_adf
@@ -175,6 +178,14 @@ class ADFMarkdownTextAreaWidget(TextArea, BaseFieldWidget, BaseUpdateFieldWidget
     ```
     """
 
+    BINDINGS = [
+        Binding('ctrl+e', 'edit_content', 'Edit', show=True, key_display='^e'),
+    ]
+
+    @dataclass
+    class EditContent(Message):
+        content: str
+
     def __init__(
         self,
         mode: FieldMode,
@@ -210,9 +221,7 @@ class ADFMarkdownTextAreaWidget(TextArea, BaseFieldWidget, BaseUpdateFieldWidget
                 markdown = str(original_value)
 
         # initialize TextArea
-        super().__init__(
-            text=markdown, id=field_id, language='markdown', tab_behavior='indent', theme='monokai'
-        )
+        super().__init__(text=markdown, id=field_id, language='markdown', tab_behavior='indent')
 
         # setup base field properties
         self.setup_base_field(
@@ -231,10 +240,10 @@ class ADFMarkdownTextAreaWidget(TextArea, BaseFieldWidget, BaseUpdateFieldWidget
                 original_value=original_value,
                 field_supports_update=field_supports_update,
             )
-            self.add_class('create-update-field-widget')
-        else:
-            # CREATE mode specific CSS
-            self.add_class('create-work-item-description')
+        self.add_class('create-work-item-description')
+
+    def action_edit_content(self):
+        self.post_message(self.EditContent(content=self.text))
 
     def get_value_for_update(self) -> dict | None:
         """Returns the value formatted for Jira API updates (UPDATE mode).

--- a/src/jiratui/widgets/commons/adf.py
+++ b/src/jiratui/widgets/commons/adf.py
@@ -73,6 +73,7 @@ class ReadOnlyADFMarkdownTextAreaWidget(Markdown):
         self._jira_field_key = jira_field_key
         self.border_title = title or jira_field_key.replace('_', ' ').title()
         self._required = required
+        self.__title = title or jira_field_key.replace('_', ' ').title()
 
         if self._required:
             self.border_subtitle = '(*)'
@@ -134,6 +135,10 @@ class ReadOnlyADFMarkdownTextAreaWidget(Markdown):
     def text_content(self) -> str:
         """Retrieves the Markdown representation of this ADF value being displayed in this widget."""
         return self.__markdown_text
+
+    @property
+    def field_title(self) -> str:
+        return self.__title
 
 
 class ADFMarkdownTextAreaWidget(TextArea, BaseFieldWidget, BaseUpdateFieldWidget):

--- a/src/jiratui/widgets/commons/tests/test_factory.py
+++ b/src/jiratui/widgets/commons/tests/test_factory.py
@@ -443,6 +443,7 @@ def test_build_read_only_rich_text_widget_with_adf_support_enabled(adf_support_e
     assert widget.field_id == 'field_a'
     assert widget.text_content == 'Some value for the ADF field\n'
     assert widget.border_title == 'Field A'
+    assert widget.field_title == 'Field A'
     assert widget.border_subtitle == '(*)'
 
 
@@ -466,4 +467,5 @@ def test_build_read_only_rich_text_widget_without_adf_support_enabled(
     assert widget.field_id == 'field_a'
     assert widget.text_content == 'Some value for the ADF field'
     assert widget.border_title == 'Field A'
+    assert widget.field_title == 'Field A'
     assert widget.border_subtitle == '(*)'

--- a/src/jiratui/widgets/commons/widgets.py
+++ b/src/jiratui/widgets/commons/widgets.py
@@ -1549,6 +1549,7 @@ class ReadOnlyPlainTextTextAreaWidget(TextArea):
         self._jira_field_key = jira_field_key
         self.border_title = title or jira_field_key.replace('_', ' ').title()
         self._required = required
+        self.__title = title or jira_field_key.replace('_', ' ').title()
 
         if self._required:
             self.border_subtitle = '(*)'
@@ -1575,6 +1576,10 @@ class ReadOnlyPlainTextTextAreaWidget(TextArea):
     @property
     def text_content(self) -> str:
         return self.text
+
+    @property
+    def field_title(self) -> str:
+        return self.__title
 
 
 # ============================================================================

--- a/src/jiratui/widgets/commons/widgets.py
+++ b/src/jiratui/widgets/commons/widgets.py
@@ -29,11 +29,14 @@ operations.
 - ReadOnlyTextAreaWidget: a TexArea widget that displays non-ADF text in read-only mode.
 """
 
+from dataclasses import dataclass
 import hashlib
 from typing import Any
 
 from dateutil.parser import isoparse  # type:ignore[import-untyped]
+from textual.binding import Binding
 from textual.events import Key
+from textual.message import Message
 from textual.validation import Number, ValidationResult
 from textual.widgets import Input, MaskedInput, Select, SelectionList, TextArea
 from textual.widgets.selection_list import Selection
@@ -1380,6 +1383,14 @@ class PlainTextTextAreaWidget(TextArea, BaseFieldWidget, BaseUpdateFieldWidget):
     ```
     """
 
+    BINDINGS = [
+        Binding('ctrl+e', 'edit_content', 'Edit', show=True, key_display='^e'),
+    ]
+
+    @dataclass
+    class EditContent(Message):
+        content: str
+
     def __init__(
         self,
         mode: FieldMode,
@@ -1423,10 +1434,10 @@ class PlainTextTextAreaWidget(TextArea, BaseFieldWidget, BaseUpdateFieldWidget):
                 original_value=original_value or '',
                 field_supports_update=field_supports_update,
             )
-            self.add_class('create-update-field-widget')
-        else:
-            # CREATE mode specific CSS
-            self.add_class('create-work-item-description')
+        self.add_class('create-work-item-description')
+
+    def action_edit_content(self):
+        self.post_message(self.EditContent(content=self.text))
 
     def get_value_for_update(self) -> str | None:
         """Returns the value formatted for Jira API updates (UPDATE mode).

--- a/src/jiratui/widgets/create_work_item/fields.py
+++ b/src/jiratui/widgets/create_work_item/fields.py
@@ -37,7 +37,7 @@ class CreateWorkItemIssueSummaryField(Input):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.border_title = 'Summary'
-        self.add_class(*['create-update-field-widget', 'required', 'summary'])
+        self.add_class(*['create-update-field-widget', 'required', 'summary', 'cols-2'])
         self.border_subtitle = '(*)'
         self._jira_field_key = 'summary'
 

--- a/src/jiratui/widgets/create_work_item/screen.py
+++ b/src/jiratui/widgets/create_work_item/screen.py
@@ -89,22 +89,19 @@ class TextAreaTabbedContent(TabbedContent):
                 return None
 
     def _edit_text_content(self, content: str) -> None:
-        if self.__configuration.enable_updating_rich_text:  # TODO what happens if this is False?
-            if not self.__configuration.text_editor:
-                self.notify(
-                    severity='error',
-                    message='Rich text editor is not enabled. Check the configuration text_editor',
-                )
-            else:
-                new_content = self._open_as_temporary_file(
-                    self.__configuration.text_editor, content
-                )
-                # update the content of the textarea widget
-                widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget | None = (
-                    self._get_textarea_widget()
-                )
-                if widget is not None:
-                    widget.text = new_content.strip() if new_content else ''
+        if not self.__configuration.text_editor:
+            self.notify(
+                severity='error',
+                message='Rich text editor is not enabled. Check config.text_editor',
+            )
+        else:
+            new_content = self._open_as_temporary_file(self.__configuration.text_editor, content)
+            # update the content of the textarea widget
+            widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget | None = (
+                self._get_textarea_widget()
+            )
+            if widget is not None:
+                widget.text = new_content.strip() if new_content else ''
 
     @on(ADFMarkdownTextAreaWidget.EditContent)
     def edit_adf_content(self, event: ADFMarkdownTextAreaWidget.EditContent) -> None:

--- a/src/jiratui/widgets/create_work_item/screen.py
+++ b/src/jiratui/widgets/create_work_item/screen.py
@@ -51,6 +51,21 @@ from jiratui.widgets.create_work_item.fields import (
 )
 
 
+class TextAreaTabPane(TabPane):
+    """A custom TabPane that contains wither ADFMarkdownTextAreaWidget or PlainTextTextAreaWidget as its child."""
+
+    def __init__(
+        self, title: str, widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget, **kwargs
+    ):
+        super().__init__(title, widget, id=f'pane-{widget.jira_field_key}', **kwargs)
+        self.__widget = widget
+        self.add_class('create-work-item-textarea-field-pane')
+
+    @property
+    def widget(self) -> ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget:
+        return self.__widget
+
+
 class TextAreaTabbedContent(TabbedContent):
     """Custom TabbedContent with a key binding for editing content."""
 
@@ -561,12 +576,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
             await self._remove_textarea_panes()
             for textarea_widget in textarea_widgets:
                 await self.textarea_fields_tabbed_content.add_pane(
-                    TabPane(
-                        textarea_widget.border_title,
-                        textarea_widget,
-                        classes='create-work-item-textarea-field-pane',
-                        id=f'pane-{textarea_widget.jira_field_key}',
-                    )
+                    TextAreaTabPane(textarea_widget.border_title, textarea_widget)
                 )
 
             # create and mount AutoComplete widgets for labels inputs and custom fields that support multiple users
@@ -605,7 +615,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
             None.
         """
 
-        if panes := self.textarea_fields_tabbed_content.query('TabPane'):
+        if panes := self.textarea_fields_tabbed_content.query(TextAreaTabPane):
             for pane in panes:
                 if pane.id != 'pane-description':
                     await self.textarea_fields_tabbed_content.remove_pane(pane.id)
@@ -757,14 +767,12 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
 
             # process textarea widgets that are created dynamically
             # iterate over every TabPane created dynamically to extract the value of its widget
-            if tab_panes := self.textarea_fields_tabbed_content.query('TabPane'):
-                pane_inner_widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget | None
+            if tab_panes := self.textarea_fields_tabbed_content.query(TextAreaTabPane):
+                pane: TextAreaTabPane
                 for pane in tab_panes:
-                    if self.adf_support_enabled:
-                        pane_inner_widget = pane.query_one_optional(ADFMarkdownTextAreaWidget)
-                    else:
-                        pane_inner_widget = pane.query_one_optional(PlainTextTextAreaWidget)
-
+                    pane_inner_widget: (
+                        ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget | None
+                    ) = pane.widget
                     if pane_inner_widget and (value := pane_inner_widget.get_value_for_create()):
                         data[pane_inner_widget.jira_field_key] = value
 

--- a/src/jiratui/widgets/create_work_item/screen.py
+++ b/src/jiratui/widgets/create_work_item/screen.py
@@ -52,7 +52,7 @@ from jiratui.widgets.create_work_item.fields import (
 
 
 class TextAreaTabPane(TabPane):
-    """A custom TabPane that contains wither ADFMarkdownTextAreaWidget or PlainTextTextAreaWidget as its child."""
+    """A custom TabPane that contains either ADFMarkdownTextAreaWidget or PlainTextTextAreaWidget as its child."""
 
     def __init__(
         self, title: str, widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget, **kwargs
@@ -89,7 +89,6 @@ class TextAreaTabbedContent(TabbedContent):
                 return None
 
     def _edit_text_content(self, content: str) -> None:
-        self.notify(content)
         if self.__configuration.enable_updating_rich_text:  # TODO what happens if this is False?
             if not self.__configuration.text_editor:
                 self.notify(
@@ -356,12 +355,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                                     field_id='description',
                                     title='Description',
                                 )
-                            yield TabPane(
-                                'Description',
-                                widget,
-                                classes='create-work-item-textarea-field-pane',
-                                id='pane-description',
-                            )
+                            yield TextAreaTabPane('Description', widget)
                 # right-hand side panel
                 with Vertical():
                     yield VerticalScroll(
@@ -766,7 +760,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                     data[field_id] = value
 
             # process textarea widgets that are created dynamically
-            # iterate over every TabPane created dynamically to extract the value of its widget
+            # iterate over every TextAreaTabPane created dynamically to extract the value of its widget
             if tab_panes := self.textarea_fields_tabbed_content.query(TextAreaTabPane):
                 pane: TextAreaTabPane
                 for pane in tab_panes:

--- a/src/jiratui/widgets/create_work_item/screen.py
+++ b/src/jiratui/widgets/create_work_item/screen.py
@@ -1,12 +1,28 @@
+import os
+import shlex
+import subprocess
+import tempfile
 from typing import Any, cast
 
 from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import ItemGrid, Vertical, VerticalScroll
+from textual.binding import Binding
+from textual.containers import Horizontal, ItemGrid, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widget import Widget
-from textual.widgets import Button, Input, Rule, Select, Static, TextArea
+from textual.widgets import (
+    Button,
+    Footer,
+    Input,
+    Rule,
+    Select,
+    Static,
+    TabbedContent,
+    TabPane,
+    TextArea,
+)
 
 from jiratui.api_controller.controller import APIControllerResponse
 from jiratui.config import CONFIGURATION
@@ -35,8 +51,92 @@ from jiratui.widgets.create_work_item.fields import (
 )
 
 
+class TextAreaTabbedContent(TabbedContent):
+    """Custom TabbedContent with a key binding for editing content."""
+
+    BINDINGS = [
+        Binding('ctrl+e', 'edit_content', 'Edit', show=True, key_display='^e'),
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__configuration = CONFIGURATION.get()
+
+    def _get_textarea_widget(self) -> ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget | None:
+        if (active_pane := self.active_pane) is None:
+            return None
+        try:
+            return active_pane.query_one(ADFMarkdownTextAreaWidget)
+        except NoMatches:
+            try:
+                return active_pane.query_one(PlainTextTextAreaWidget)
+            except NoMatches:
+                return None
+
+    def _edit_text_content(self, content: str) -> None:
+        self.notify(content)
+        if self.__configuration.enable_updating_rich_text:  # TODO what happens if this is False?
+            if not self.__configuration.text_editor:
+                self.notify(
+                    severity='error',
+                    message='Rich text editor is not enabled. Check the configuration text_editor',
+                )
+            else:
+                new_content = self._open_as_temporary_file(
+                    self.__configuration.text_editor, content
+                )
+                # update the content of the textarea widget
+                widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget | None = (
+                    self._get_textarea_widget()
+                )
+                if widget is not None:
+                    widget.text = new_content.strip() if new_content else ''
+
+    @on(ADFMarkdownTextAreaWidget.EditContent)
+    def edit_adf_content(self, event: ADFMarkdownTextAreaWidget.EditContent) -> None:
+        self._edit_text_content(event.content)
+
+    @on(PlainTextTextAreaWidget.EditContent)
+    def edit_plain_text_content(self, event: PlainTextTextAreaWidget.EditContent) -> None:
+        self._edit_text_content(event.content)
+
+    def action_edit_content(self) -> None:
+        """Handle '^e' key press in this widget."""
+        widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget | None = (
+            self._get_textarea_widget()
+        )
+        if widget is not None:
+            self.notify(f'Trying to update content of the textarea widget: {widget.id}')
+            self._edit_text_content(widget.text)
+
+    def _open_as_temporary_file(self, command: str, content: str) -> str:
+        editor_args: list[str] = shlex.split(command)
+        with tempfile.NamedTemporaryFile(suffix='.md', delete=False) as temp_file:
+            temp_file_name = temp_file.name
+            temp_file.write(content.encode('utf-8'))
+            temp_file.flush()
+
+        editor_args.append(temp_file_name)
+        with self.app.suspend():
+            try:
+                subprocess.call(editor_args)
+            except OSError:
+                self.app.notify(
+                    severity='error',
+                    title="Can't run command",
+                    message=f'The command [b]{command}[/b] failed to run.',
+                )
+
+        new_content = content
+        with open(temp_file_name, 'r', encoding='utf-8') as temp_file:
+            new_content = temp_file.read()
+
+        os.remove(temp_file_name)
+        return new_content
+
+
 class AddWorkItemScreen(Screen[dict[str, Any]]):
-    """A modal screen for adding work items.
+    """A modal screen for creating work items.
 
     The screen is pushed from the main screen of the application. It is responsible for:
 
@@ -62,8 +162,13 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
     ```
     """
 
-    BINDINGS = [('escape', 'app.pop_screen', 'Close')]
-    TITLE = 'Create Work Item'
+    BINDINGS = [
+        Binding('ctrl+s', 'save_work_item', 'Save', show=True, key_display='^s'),
+        Binding('escape', 'app.pop_screen', 'Close'),
+    ]
+
+    TITLE = 'New Work Item'
+    HELP = 'See Creating Work Items section in the help'
 
     def __init__(
         self,
@@ -94,7 +199,12 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
         self.__configuration = CONFIGURATION.get()
 
     @property
+    def help_anchor(self) -> str:
+        return '#creating-work-items'
+
+    @property
     def adf_support_enabled(self) -> bool:
+        # determines if the application is connecting to a Jira API instance that supports ADF
         return self.__configuration.cloud and self.__configuration.jira_api_version == 3
 
     @property
@@ -136,8 +246,8 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
     @property
     def description_field(self) -> ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget:
         if self.adf_support_enabled:
-            return self.query_one(ADFMarkdownTextAreaWidget)
-        return self.query_one(PlainTextTextAreaWidget)
+            return self.query_one('#description', expect_type=ADFMarkdownTextAreaWidget)
+        return self.query_one('#description', expect_type=PlainTextTextAreaWidget)
 
     @property
     def parent_key_field(self) -> CreateWorkItemParentKeyField:
@@ -146,6 +256,10 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
     @property
     def additional_fields(self) -> VerticalScroll:
         return self.query_one('#create-additional-fields', expect_type=VerticalScroll)
+
+    @property
+    def textarea_fields_tabbed_content(self) -> TextAreaTabbedContent:
+        return self.query_one('#textarea-fields-tabs', expect_type=TextAreaTabbedContent)
 
     def _validate_required_fields(self) -> bool:
         """Checks if all required fields for saving the form data have values.
@@ -178,58 +292,72 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
         vertical.border_title = self.TITLE
         with vertical:
             yield Static(
-                Text(
-                    'You can configure the additional fields to exclude via the variables config.enable_creating_additional_fields and config.create_additional_fields_ignore_ids'
-                ),
-                classes='create-work-item-tip',
+                Text('Important: fields marked with (*) are required.', style='orange italic')
             )
-            yield Static(
-                Text('Important: fields marked with (*) are required.', style='orange italic'),
-            )
-            yield Rule(classes='rule-20')
-            with VerticalScroll(id='add-work-item-form'):
-                with ItemGrid(classes='add-work-item-fields-grid'):
-                    # set widgets in row 1
-                    yield CreateWorkItemProjectSelectionInput()
-                    yield CreateWorkItemIssueTypeSelectionInput([])
-                    # set widgets in row 2
-                    # this input field contains the account id of the Jira user that we can use to set the item's
-                    # reporter field
-                    yield JiraUserInput(
-                        id='create-work-item-reporter-selector',
-                        border_title='Reporter',
-                        border_subtitle='(*)',
-                        jira_field_key='reporter_account_id',
-                    ).add_class(*['required', 'create-update-users-field-widget'])
-                    # this input field contains the account id of the Jira user that we can use to set the item's
-                    # assignee field
-                    yield JiraUserInput(
-                        id='create-work-item-assignee-selector',
-                        border_title='Assignee',
-                        jira_field_key='assignee_account_id',
-                    ).add_class(*['create-update-users-field-widget'])
-                yield CreateWorkItemParentKeyField(self._parent_work_item_key)
-                yield CreateWorkItemIssueSummaryField()
-                if self.adf_support_enabled:
-                    yield ADFMarkdownTextAreaWidget(
-                        mode=FieldMode.CREATE,
-                        jira_field_key='description',
-                        field_id='description',
-                        title='Description',
-                    )
-                else:
-                    yield PlainTextTextAreaWidget(
-                        mode=FieldMode.CREATE,
-                        jira_field_key='description',
-                        field_id='description',
-                        title='Description',
-                    )
-                yield VerticalScroll(id='create-additional-fields')
-            with ItemGrid(classes='add-work-item-grid-buttons'):
-                yield Button(
-                    'Save', variant='success', id='add-work-item-button-save', disabled=True
-                )
-                yield Button('Cancel', variant='error', id='add-work-item-button-quit')
+            yield Rule()
+            with Horizontal():
+                # left-hand side panel
+                with VerticalScroll(classes='add-work-item-form'):
+                    # statically-defined widgets
+                    with ItemGrid(classes='add-work-item-fields-grid'):
+                        # set widgets in row 1
+                        yield CreateWorkItemProjectSelectionInput()
+                        yield CreateWorkItemIssueTypeSelectionInput([])
+                        # set widgets in row 2
+                        # this input field contains the account id of the Jira user that we can use to set the item's
+                        # reporter field
+                        yield JiraUserInput(
+                            id='create-work-item-reporter-selector',
+                            border_title='Reporter',
+                            border_subtitle='(*)',
+                            jira_field_key='reporter_account_id',
+                        ).add_class(*['required', 'create-update-users-field-widget'])
+                        # this input field contains the account id of the Jira user that we can use to set the item's
+                        # assignee field
+                        yield JiraUserInput(
+                            id='create-work-item-assignee-selector',
+                            border_title='Assignee',
+                            jira_field_key='assignee_account_id',
+                        ).add_class(*['create-update-users-field-widget'])
+                        yield CreateWorkItemIssueSummaryField()
+                        yield CreateWorkItemParentKeyField(self._parent_work_item_key)
+                    # dynamically-created widgets
+                    with VerticalScroll(classes='add-work-item-form-textarea-fields'):
+                        with TextAreaTabbedContent(
+                            id='textarea-fields-tabs'
+                        ):  # Container for dynamic fields - textarea fields
+                            widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget
+                            if self.adf_support_enabled:
+                                widget = ADFMarkdownTextAreaWidget(
+                                    mode=FieldMode.CREATE,
+                                    jira_field_key='description',
+                                    field_id='description',
+                                    title='Description',
+                                )
+                            else:
+                                widget = PlainTextTextAreaWidget(
+                                    mode=FieldMode.CREATE,
+                                    jira_field_key='description',
+                                    field_id='description',
+                                    title='Description',
+                                )
+                            yield TabPane(
+                                'Description',
+                                widget,
+                                classes='create-work-item-textarea-field-pane',
+                                id='pane-description',
+                            )
+                # right-hand side panel
+                with Vertical():
+                    yield VerticalScroll(
+                        id='create-additional-fields'
+                    )  # Container for dynamic fields - non-textarea fields
+                    with ItemGrid(classes='add-work-item-grid-buttons'):
+                        yield Button(
+                            'Save', variant='success', id='add-work-item-button-save', disabled=True
+                        )
+                        yield Button('Cancel', variant='error', id='add-work-item-button-quit')
+        yield Footer(compact=True, show_command_palette=False)
 
     def on_mount(self):
         """Mounts the widgets.
@@ -289,6 +417,9 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
         """Fetches the applicable types of work items for the selected project and updates the issue type dropdown
         widget.
 
+        This also removes all the dynamically-created textarea-based widgets. This does not remove the pane that
+        contains the description widget.
+
         Args:
             project_key: the key of the project selected by the user.
 
@@ -298,6 +429,10 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
 
         application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
         key = project_key or self.project_selector.selection
+        # clean up the panes that contain dynamically-created textarea-based widgets
+        await self._remove_textarea_panes()
+        # clean up the list of options
+        self.issue_type_selector.set_options([])
         if key:
             response: APIControllerResponse = await application.api.get_issue_types_for_project(key)
             types: list[IssueType] = []
@@ -311,13 +446,17 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
     def handle_project_selection(self) -> None:
         """Fetches the applicable types of work items for creating issues in the selected project.
 
-        This also updates the status of the "Save" button.
+        This also:
+        - updates the status of the "Save" button.
+        - remove all the panes used for displaying textarea-based field widgets.
 
         Returns:
             None.
         """
 
         self.run_worker(self.fetch_available_issue_types(self.project_selector.selection))
+        # clean up the panes that contain textarea-based widgets
+        self.additional_fields.remove_children()
         self.save_button.disabled = not self._validate_required_fields()
 
     @on(Select.Changed, 'CreateWorkItemIssueTypeSelectionInput')
@@ -403,7 +542,32 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                 api_controller=application.api,
                 adf_support_enabled=self.adf_support_enabled,
             )
-            await self.additional_fields.mount_all(metadata_fields)
+
+            # split the fields based on type so we can mount them in different places in the UI
+            textarea_widgets: list[ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget] = []
+            non_textarea_widgets: list[Widget] = []
+            for widget in metadata_fields:
+                if isinstance(widget, ADFMarkdownTextAreaWidget) or isinstance(
+                    widget, PlainTextTextAreaWidget
+                ):
+                    textarea_widgets.append(widget)
+                else:
+                    non_textarea_widgets.append(widget)
+
+            # mount the (non-textarea) widgets on the left column
+            await self.additional_fields.mount_all(non_textarea_widgets)
+            # mount the widgets on the right column but before make sure we remove all the panes except the
+            # statically-defined pane that contains the description widget
+            await self._remove_textarea_panes()
+            for textarea_widget in textarea_widgets:
+                await self.textarea_fields_tabbed_content.add_pane(
+                    TabPane(
+                        textarea_widget.border_title,
+                        textarea_widget,
+                        classes='create-work-item-textarea-field-pane',
+                        id=f'pane-{textarea_widget.jira_field_key}',
+                    )
+                )
 
             # create and mount AutoComplete widgets for labels inputs and custom fields that support multiple users
             for input_widget in self.additional_fields.query(Input):
@@ -430,6 +594,21 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                     await self.additional_fields.mount(
                         UsersAutoComplete(target=input_widget, api_controller=application.api)
                     )
+
+    async def _remove_textarea_panes(self) -> None:
+        """Removes the panes that contain dynamically-created textarea-based widgets.
+
+        Important: this does not remove the description's widget because we always need at least 1 pane in the tabbed
+        content widget.
+
+        Returns:
+            None.
+        """
+
+        if panes := self.textarea_fields_tabbed_content.query('TabPane'):
+            for pane in panes:
+                if pane.id != 'pane-description':
+                    await self.textarea_fields_tabbed_content.remove_pane(pane.id)
 
     @staticmethod
     def _format_field_value(field_id: str, value: Any, field_metadata: dict) -> Any:
@@ -492,6 +671,9 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
         # default: pass value as-is
         return value
 
+    def action_save_work_item(self) -> None:
+        self.handle_save()
+
     @on(Button.Pressed, '#add-work-item-button-save')
     def handle_save(self) -> None:
         """Builds the necessary payload data for creating a new work item.
@@ -501,7 +683,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
         payload.
 
         Returns:
-            None.
+            None
         """
 
         if not self._validate_required_fields():
@@ -527,7 +709,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
             if self._reporter_is_editable:
                 data[self.reporter_selector.jira_field_key] = self.reporter_selector.account_id
 
-            # process widgets that are created dynamically
+            # process non-textarea widgets that are created dynamically
             for widget in self.additional_fields.children:
                 if not hasattr(widget, 'field_id'):
                     continue
@@ -552,12 +734,6 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                     if value := widget.get_value_for_create():
                         data[widget.jira_field_key] = value
                     continue
-                elif isinstance(widget, ADFMarkdownTextAreaWidget) or isinstance(
-                    widget, PlainTextTextAreaWidget
-                ):
-                    if value := widget.get_value_for_create():
-                        data[widget.jira_field_key] = value
-                    continue
                 elif isinstance(widget, Select):
                     value = widget.selection
                 elif isinstance(widget, Input):
@@ -578,6 +754,19 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                 elif value:
                     # no metadata available, pass as-is
                     data[field_id] = value
+
+            # process textarea widgets that are created dynamically
+            # iterate over every TabPane created dynamically to extract the value of its widget
+            if tab_panes := self.textarea_fields_tabbed_content.query('TabPane'):
+                pane_inner_widget: ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget | None
+                for pane in tab_panes:
+                    if self.adf_support_enabled:
+                        pane_inner_widget = pane.query_one_optional(ADFMarkdownTextAreaWidget)
+                    else:
+                        pane_inner_widget = pane.query_one_optional(PlainTextTextAreaWidget)
+
+                    if pane_inner_widget and (value := pane_inner_widget.get_value_for_create()):
+                        data[pane_inner_widget.jira_field_key] = value
 
             self.notify('Creating the work item...', title='Create Work Item')
             self.dismiss(data)

--- a/src/jiratui/widgets/create_work_item/tests/test_create_work_item.py
+++ b/src/jiratui/widgets/create_work_item/tests/test_create_work_item.py
@@ -794,7 +794,7 @@ async def test_save_includes_additional_fields_with_adf_support_enabled(
 @patch.object(AddWorkItemScreen, 'adf_support_enabled', PropertyMock(return_value=False))
 @patch.object(APIController, 'get_issue_create_metadata')
 @pytest.mark.asyncio
-async def test_save_includes_additional_fields_without_adf_support_enabled(
+async def test_save_includes_additional_fields_with_adf_support_disabled(
     get_issue_create_metadata_mock: AsyncMock, app, create_metadata_with_editable_reporter
 ):
     """Test that save handler includes additional fields and the same reporter and assignee."""

--- a/src/jiratui/widgets/work_item_details/read_only_details.py
+++ b/src/jiratui/widgets/work_item_details/read_only_details.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import cast
 
 from rich.text import Text
 from textual import log
@@ -55,7 +56,8 @@ class WorkItemReadOnlyDetailsScreen(ModalScreen):
     async def on_mount(self) -> None:
         if not self._work_item_key:
             return
-        response: APIControllerResponse = await self.parent.api.get_issue(  # type:ignore[attr-defined]
+        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
+        response: APIControllerResponse = await application.api.get_issue(  # type:ignore[attr-defined]
             issue_id_or_key=self._work_item_key
         )
         if not response.success:
@@ -136,7 +138,7 @@ class WorkItemReadOnlyDetailsScreen(ModalScreen):
             # set the content of the description tab
             widget: ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
             if issue.rich_text_value_is_empty(issue.description):
-                widget = Static('There is no Description set. Press "e" to edit it.', classes='tip')
+                widget = Static('There is no Description set.', classes='tip')
             else:
                 widget = build_read_only_rich_text_widget(
                     jira_field_key='description',
@@ -173,7 +175,7 @@ class WorkItemReadOnlyDetailsScreen(ModalScreen):
                         if metadata.key.lower() == JiraWorkItemFields.ENVIRONMENT.value:
                             if issue.rich_text_value_is_empty(issue.environment):
                                 widget = Static(
-                                    f'There is no "{field_name}" set. Press "e" to edit it.',
+                                    f'There is no "{field_name}" set.',
                                     classes='tip',
                                 )
                             else:
@@ -188,7 +190,7 @@ class WorkItemReadOnlyDetailsScreen(ModalScreen):
                             field_value = issue.get_custom_field_value(field_id)
                             if issue.rich_text_value_is_empty(field_value):
                                 widget = Static(
-                                    f'There is no "{field_name}" set. Press "e" to edit it.',
+                                    f'There is no "{field_name}" set.',
                                     classes='tip',
                                 )
                             else:
@@ -200,5 +202,10 @@ class WorkItemReadOnlyDetailsScreen(ModalScreen):
                                 )
 
                         await tabbed.add_pane(
-                            TabPane(metadata.name, widget, classes='summary-description-container')
+                            TabPane(
+                                metadata.name,
+                                widget,
+                                id=f'tab-{field_id}',
+                                classes='summary-description-container',
+                            )
                         )

--- a/src/jiratui/widgets/work_item_details/tests/test_read_only_details.py
+++ b/src/jiratui/widgets/work_item_details/tests/test_read_only_details.py
@@ -1,0 +1,209 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from textual.widgets import DataTable, Static, TabPane
+
+from jiratui.api_controller.controller import APIController, APIControllerResponse
+from jiratui.models import IssueStatus, IssueType, JiraIssue, JiraIssueSearchResponse, Project
+from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
+from jiratui.widgets.work_item_details.read_only_details import WorkItemReadOnlyDetailsScreen
+
+
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_read_only_details_without_description(
+    get_issue_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    work_item.description = None
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    async with app.run_test():
+        screen = WorkItemReadOnlyDetailsScreen('WI-1')
+        # WHEN
+        await app.push_screen(screen)
+        await app.workers.wait_for_complete()
+        # THEN
+        dt = screen.query_one(DataTable)
+        assert dt.row_count == 13
+        tab_description = screen.query_one('#tab-description', expect_type=TabPane)
+        assert isinstance(tab_description.children[0], Static)
+        assert tab_description.children[0].content == 'There is no Description set.'
+
+
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_read_only_details_with_description(
+    get_issue_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    work_item.description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [
+            {
+                'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
+                'type': 'paragraph',
+            }
+        ],
+    }
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[jira_issues[1]])
+    )
+    async with app.run_test():
+        screen = WorkItemReadOnlyDetailsScreen('WI-1')
+        # WHEN
+        await app.push_screen(screen)
+        await app.workers.wait_for_complete()
+        # THEN
+        dt = screen.query_one(DataTable)
+        assert dt.row_count == 13
+        tab_description = screen.query_one('#tab-description', expect_type=TabPane)
+        assert isinstance(tab_description.children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert tab_description.children[0].text_content == 'Some value for the ADF field\n'
+
+
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_read_only_details_without_description_without_edit_metadata(
+    get_issue_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    work_item.description = None
+    work_item.edit_metadata = None
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    async with app.run_test():
+        screen = WorkItemReadOnlyDetailsScreen('WI-1')
+        # WHEN
+        await app.push_screen(screen)
+        await app.workers.wait_for_complete()
+        # THEN
+        dt = screen.query_one(DataTable)
+        assert dt.row_count == 13
+        tab_description = screen.query_one('#tab-description', expect_type=TabPane)
+        assert isinstance(tab_description.children[0], Static)
+
+
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_read_only_details_without_description_with_edit_metadata(
+    get_issue_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = JiraIssue(
+        id='1',
+        key='WI-1',
+        summary='abcd',
+        description='',
+        project=Project(id='2', name='Project 2', key='P2'),
+        created=datetime(2025, 10, 31),
+        updated=datetime(2025, 10, 31),
+        status=IssueStatus(name='Done', id='1'),
+        issue_type=IssueType(id='1', name='Task'),
+        edit_meta={
+            'fields': {
+                'field_a': {
+                    'schema': {
+                        'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:textarea'
+                    },
+                    'key': 'field_a',
+                    'name': 'Field A',
+                    'required': False,
+                },
+            }
+        },
+        custom_fields={
+            'field_a': {
+                'type': 'doc',
+                'version': 1,
+                'content': [
+                    {
+                        'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
+                        'type': 'paragraph',
+                    }
+                ],
+            },
+        },
+    )
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    async with app.run_test():
+        screen = WorkItemReadOnlyDetailsScreen('WI-1')
+        # WHEN
+        await app.push_screen(screen)
+        await app.workers.wait_for_complete()
+        # THEN
+        dt = screen.query_one(DataTable)
+        assert dt.row_count == 13
+        tab_description = screen.query_one('#tab-description', expect_type=TabPane)
+        assert isinstance(tab_description.children[0], Static)
+        tab = screen.query_one('#tab-field_a', expect_type=TabPane)
+        assert isinstance(tab.children[0], ReadOnlyADFMarkdownTextAreaWidget)
+
+
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_read_only_details_without_description_with_edit_metadata_without_field_value(
+    get_issue_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = JiraIssue(
+        id='1',
+        key='WI-1',
+        summary='abcd',
+        description='',
+        project=Project(id='2', name='Project 2', key='P2'),
+        created=datetime(2025, 10, 31),
+        updated=datetime(2025, 10, 31),
+        status=IssueStatus(name='Done', id='1'),
+        issue_type=IssueType(id='1', name='Task'),
+        edit_meta={
+            'fields': {
+                'field_a': {
+                    'schema': {
+                        'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:textarea'
+                    },
+                    'key': 'field_a',
+                    'name': 'Field A',
+                    'required': False,
+                },
+            }
+        },
+        custom_fields={
+            'field_a': None,
+        },
+    )
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    async with app.run_test():
+        screen = WorkItemReadOnlyDetailsScreen('WI-1')
+        # WHEN
+        await app.push_screen(screen)
+        await app.workers.wait_for_complete()
+        # THEN
+        dt = screen.query_one(DataTable)
+        assert dt.row_count == 13
+        tab_description = screen.query_one('#tab-description', expect_type=TabPane)
+        assert isinstance(tab_description.children[0], Static)
+        tab = screen.query_one('#tab-field_a', expect_type=TabPane)
+        assert isinstance(tab.children[0], Static)
+        assert tab.children[0].content == 'There is no "Field A" set.'

--- a/src/jiratui/widgets/work_item_info/info.py
+++ b/src/jiratui/widgets/work_item_info/info.py
@@ -8,16 +8,19 @@ from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, ItemGrid, Vertical, VerticalGroup, VerticalScroll
+from textual.css.query import NoMatches
 from textual.message import Message
 from textual.reactive import Reactive, reactive
 from textual.screen import ModalScreen, Screen
 from textual.widgets import (
     Button,
-    Collapsible,
+    Footer,
     LoadingIndicator,
     MarkdownViewer,
     Rule,
     Static,
+    TabbedContent,
+    TabPane,
     TextArea,
 )
 
@@ -31,108 +34,6 @@ from jiratui.widgets.commons.factory_utils import (
     build_read_only_rich_text_widget,
 )
 from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget
-
-
-class TextareaCollapsible(Collapsible):
-    BINDINGS = [
-        Binding(
-            key='ctrl+e',
-            action='edit_content',
-            description='Edit',
-            key_display='^e',
-        ),
-        Binding(
-            key='v',
-            action='view_content',
-            description='View',
-            key_display='v',
-        ),
-        Binding(
-            key='c',
-            action='copy_content',
-            description='Copy',
-            key_display='c',
-        ),
-    ]
-
-    class DisplayContent(Message):
-        def __init__(self, content: str, title: str | None = None):
-            super().__init__()
-            self.content = content
-            self.title = title
-
-    class EditContent(Message):
-        def __init__(
-            self, jira_field_key: str, content: str | None = None, title: str | None = None
-        ):
-            super().__init__()
-            self.content = content or ''
-            self.jira_field_key = jira_field_key
-            self.title = title
-
-    def __init__(
-        self,
-        jira_field_key: str,
-        field_name: str,
-        widget: ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static,
-        required: bool = False,
-        **kwargs,
-    ):
-        self.__configuration = CONFIGURATION.get()
-        self._jira_field_key: str = jira_field_key
-
-        self.__widget: (
-            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
-        ) = widget
-
-        # the string representation of the content stored in the widget within this collapsible.
-        # this will contain '' when the content is empty but the Collapsible contains a Static widget
-        if isinstance(self.__widget, Static):
-            self.__content: str = ''
-        else:
-            self.__content = self.__widget.text_content or ''
-
-        # initialize the Collapsible widget
-        super().__init__(self.__widget, **kwargs)
-        self.border_title = field_name
-        self.title = ''  # let's not set a text next to the arrows for toggling content
-        self.add_class('textarea-collapsible')
-        if required:
-            self.border_subtitle = '(*)'
-            self.add_class('required')
-
-    @property
-    def widget(
-        self,
-    ) -> ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static:
-        return self.__widget
-
-    @property
-    def text_content(self) -> str:
-        return self.__content
-
-    @property
-    def _updating_rich_text_is_enabled(self) -> bool:
-        # for easy mocking in tests
-        return self.__configuration.enable_updating_rich_text
-
-    def action_view_content(self):
-        if self.__content:
-            self.post_message(self.DisplayContent(self.__content, self.border_title))
-        else:
-            self.notify('The field has no content to display. Press "e" to edit it.')
-
-    def action_edit_content(self):
-        if self._updating_rich_text_is_enabled:
-            self.post_message(
-                self.EditContent(self._jira_field_key, self.__content, self.border_title)
-            )
-
-    def action_copy_content(self) -> None:
-        """Copy to the clipboard the content of the field."""
-        if self.__content and self.__content.strip():
-            self.app.copy_to_clipboard(self.__content.strip())
-            self.notify('Content copied!')
 
 
 class DisplayTextContentScreen(ModalScreen):
@@ -150,7 +51,10 @@ class DisplayTextContentScreen(ModalScreen):
 class EditTextContentScreen(Screen[dict]):
     """A modal screen that displays a TextArea editor to allow users to edit Plain Text/Markdown content."""
 
-    BINDINGS = [('escape', 'app.pop_screen', 'Close')]
+    BINDINGS = [
+        Binding('escape', 'app.pop_screen', 'Close'),
+        Binding('ctrl+s', 'save_content', 'Save', show=True, key_display='^s'),
+    ]
 
     def __init__(self, content: str, jira_field_key: str, title: str | None = None):
         super().__init__()
@@ -165,7 +69,11 @@ class EditTextContentScreen(Screen[dict]):
     def compose(self) -> ComposeResult:
         with Vertical():
             widget = TextArea.code_editor(
-                self.__content, language='markdown', show_line_numbers=False, compact=True
+                self.__content,
+                language='markdown',
+                show_line_numbers=False,
+                compact=True,
+                theme='css',
             )
             widget.border_title = self.title
             yield widget
@@ -182,6 +90,8 @@ class EditTextContentScreen(Screen[dict]):
                     id='edit-description-button-quit',
                     classes='save-cancel-buttons',
                 )
+            yield Static()
+        yield Footer(compact=True, show_command_palette=False)
 
     def on_mount(self):
         self.post_message(TextArea.Changed(self.query_one(TextArea)))
@@ -198,6 +108,108 @@ class EditTextContentScreen(Screen[dict]):
         self.dismiss(
             {'content': self.textarea.text.strip(), 'jira_field_key': self.__jira_field_key}
         )
+
+    def action_save_content(self) -> None:
+        self.handle_save()
+
+
+class TextAreaTabPane(TabPane):
+    """A custom TabPane that contains either ReadOnlyADFMarkdownTextAreaWidget or ReadOnlyPlainTextTextAreaWidget as
+    its child."""
+
+    def __init__(self, title: str, widget_id: str, **kwargs):
+        super().__init__(title=title, id=widget_id, **kwargs)
+
+
+class InfoTabbedContent(TabbedContent):
+    """Custom TabbedContent with key bindings for editing, viewing and copying the content of the currently active
+    pane/tab."""
+
+    BINDINGS = [
+        Binding(
+            key='ctrl+e', action='edit_content', description='Edit', show=True, key_display='^e'
+        ),
+        Binding(key='v', action='view_content', description='View', key_display='v'),
+        Binding(key='c', action='copy_content', description='Copy', key_display='c'),
+    ]
+
+    class DisplayContent(Message):
+        def __init__(self, content: str, title: str | None = None):
+            super().__init__()
+            self.content = content
+            self.title = title
+
+    class EditContent(Message):
+        def __init__(
+            self, jira_field_key: str, content: str | None = None, title: str | None = None
+        ):
+            super().__init__()
+            self.content = content or ''
+            self.jira_field_key = jira_field_key
+            self.title = title
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _get_textarea_widget(
+        self,
+    ) -> ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None:
+        if (active_pane := self.active_pane) is None:
+            return None
+        try:
+            return active_pane.query_one(ReadOnlyADFMarkdownTextAreaWidget)
+        except NoMatches:
+            try:
+                return active_pane.query_one(ReadOnlyPlainTextTextAreaWidget)
+            except NoMatches:
+                try:
+                    return active_pane.query_one(Static)
+                except NoMatches:
+                    return None
+
+    def action_edit_content(self) -> None:
+        """Sends an `InfoTabbedContent.EditContent` message to the parent to edit the content of the active pane's
+        widget."""
+
+        widget: (
+            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+        ) = self._get_textarea_widget()
+        if widget is not None:
+            if isinstance(widget, Static):
+                content_to_edit = ''
+                jira_field_key = widget.id
+                title = widget.name
+            else:
+                content_to_edit = widget.text_content
+                jira_field_key = widget.jira_field_key
+                title = widget.field_title
+            self.post_message(self.EditContent(jira_field_key, content_to_edit, title))
+
+    def action_view_content(self) -> None:
+        """Sends an `InfoTabbedContent.DisplayContent` message to the parent to view the content of the active
+        pane's widget."""
+
+        widget: (
+            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+        ) = self._get_textarea_widget()
+        if widget is not None:
+            if isinstance(widget, Static):
+                self.notify(f'The field {widget.name} has no content. Press "^e" to edit it.')
+            else:
+                self.post_message(self.DisplayContent(widget.text_content, widget.field_title))
+
+    def action_copy_content(self) -> None:
+        """Copy to the clipboard the content of the field."""
+
+        widget: (
+            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+        ) = self._get_textarea_widget()
+        if widget is not None:
+            if isinstance(widget, Static):
+                self.notify(f'The field {widget.name} has no content. Press "^e" to edit it.')
+            else:
+                self.app.copy_to_clipboard(widget.text_content.strip())
+                self.notify('Content copied!')
 
 
 class WorkItemInfoContainer(Vertical):
@@ -221,11 +233,6 @@ class WorkItemInfoContainer(Vertical):
         self.can_focus = True
         self.__configuration = CONFIGURATION.get()
 
-    @on(TextareaCollapsible.DisplayContent)
-    def _display_content(self, event: TextareaCollapsible.DisplayContent) -> None:
-        self.app.push_screen(DisplayTextContentScreen(event.content, event.title))
-        event.stop()
-
     @property
     def _updating_rich_text_is_enabled(self) -> bool:
         return self.__configuration.enable_updating_rich_text
@@ -242,8 +249,8 @@ class WorkItemInfoContainer(Vertical):
     def _editor(self) -> str | None:
         return self.__configuration.text_editor
 
-    @on(TextareaCollapsible.EditContent)
-    def _edit_content(self, event: TextareaCollapsible.EditContent) -> None:
+    @on(InfoTabbedContent.EditContent)
+    def _edit_content(self, event: InfoTabbedContent.EditContent) -> None:
         if self._updating_rich_text_is_enabled:
             if self._editor:
                 new_content = self._open_as_temporary_file(self._editor, event.content)
@@ -253,14 +260,21 @@ class WorkItemInfoContainer(Vertical):
                     )
                 )
             else:
+                # fallback to built-in rudimentary editor
                 self.app.push_screen(
                     EditTextContentScreen(event.content, event.jira_field_key, event.title),
                     self._update_field,
                 )
         event.stop()
 
+    @on(InfoTabbedContent.DisplayContent)
+    def _display_content(self, event: InfoTabbedContent.DisplayContent) -> None:
+        self.app.push_screen(DisplayTextContentScreen(event.content, event.title))
+        event.stop()
+
     async def _update_field(self, data: dict) -> None:
         """Updates the value of a text-based field in the work item."""
+
         if self._updating_rich_text_is_enabled:
             application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
             payload = {data.get('jira_field_key'): data.get('content')}
@@ -295,8 +309,12 @@ class WorkItemInfoContainer(Vertical):
         return self.query_one('#work-item-info-content', expect_type=VerticalGroup)
 
     @property
-    def collapsible_container(self) -> VerticalScroll:
-        return self.query_one('#collapsible-container', expect_type=VerticalScroll)
+    def tabs_container(self) -> VerticalScroll:
+        return self.query_one('#tabs-container', expect_type=VerticalScroll)
+
+    @property
+    def info_tabbed_content(self) -> InfoTabbedContent:
+        return self.query_one('#info-tabbed-content', expect_type=InfoTabbedContent)
 
     def compose(self) -> ComposeResult:
         with Center(id='work-item-info-loading-container') as loading_container:
@@ -306,58 +324,88 @@ class WorkItemInfoContainer(Vertical):
             vg.can_focus = False
             yield Static(id='issue_summary', markup=False)
             yield Rule()
-            yield VerticalScroll(id='collapsible-container', classes='work-item-info-collapsible')
+            with VerticalScroll(id='tabs-container', classes='work-item-info-tabs-container'):
+                yield InfoTabbedContent(
+                    id='info-tabbed-content'
+                )  # Container for dynamic fields - textarea fields
+
+    def watch_issue(self, work_item: JiraIssue | None) -> None:
+        self.run_worker(self._refresh_tabs_and_set_work_item(work_item))
+
+    def _clear_static_widgets(self) -> None:
+        self.issue_summary_widget.update('')
+        self.issue_summary_widget.visible = False
+        self.query_one(Rule).visible = False
 
     async def _setup_work_item_description(self, work_item: JiraIssue) -> None:
         if issue_edit_metadata := work_item.get_edit_metadata():
             if field_metadata := issue_edit_metadata.get(JiraWorkItemFields.DESCRIPTION.value, {}):
                 field_name = field_metadata.get('name', field_metadata.get('key')).title()
-                widget_for_collapsible: (
-                    ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
-                )
+                widget: ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
                 if work_item.rich_text_value_is_empty(work_item.description):  # type:ignore[arg-type]
-                    widget_for_collapsible = Static(
-                        f'There is no "{field_name}" set. Press "e" to edit it.', classes='tip'
+                    widget = Static(
+                        f'There is no "{field_name}" set. Press "^e" to edit it.', classes='tip'
                     )
                 else:
-                    widget_for_collapsible = build_read_only_rich_text_widget(
+                    widget = build_read_only_rich_text_widget(
                         jira_field_key=field_metadata.get('key'),
                         field_name=field_name,
                         required=field_metadata.get('required', False),
                         content=work_item.description,
                     )
-                collapsible = TextareaCollapsible(
-                    jira_field_key=field_metadata.get('key'),
-                    widget=widget_for_collapsible,
-                    field_name=field_name,
-                    required=field_metadata.get('required', False),
-                    collapsed=False,
-                )
-                await self.collapsible_container.mount(collapsible)
+                pane = TextAreaTabPane(title='Description', widget_id='pane-description')
+                await self.info_tabbed_content.add_pane(pane)
+                await pane.mount(widget)
 
-    def watch_issue(self, work_item: JiraIssue | None) -> None:
-        # "reset" the information of any previous widget
-        self.clear_information = True
+    async def _refresh_tabs_and_set_work_item(self, work_item: JiraIssue | None):
+        self._clear_static_widgets()
 
-        if not work_item:
-            return None
+        # re-build the InfoTabbedContent widget by removing it first
+        info_tabbed_content: InfoTabbedContent | None = self.query_one_optional(
+            '#info-tabbed-content', expect_type=InfoTabbedContent
+        )
+        if info_tabbed_content is not None:
+            # remove all existing TextAreaTabPane children
+            await info_tabbed_content.query(TextAreaTabPane).remove()
+            # remove the tabbed content widget
+            await info_tabbed_content.remove()
 
-        # set the summary of the work item and make the widget visible
-        self.issue_summary_widget.update(work_item.summary)
-        self.issue_summary_widget.visible = True
-        self.query_one(Rule).visible = True
+        # create and mount a new InfoTabbedContent
+        await self.tabs_container.mount(InfoTabbedContent(id='info-tabbed-content'))
 
-        # set the description of the work item and make the widget visible
-        self.run_worker(self._setup_work_item_description(work_item))
+        if work_item:
+            # set the summary and make the widget visible
+            self.issue_summary_widget.update(work_item.summary)
+            self.issue_summary_widget.visible = True
+            self.query_one(Rule).visible = True
 
-        # build widgets for the fields with rich-text support
-        if self._enable_updating_additional_fields:
-            widgets: list[TextareaCollapsible] = self._build_textarea_widgets(work_item)
-            self.collapsible_container.mount_all(widgets)
-        return None
+            # set the description
+            await self._setup_work_item_description(work_item)
 
-    def _build_textarea_widgets(self, work_item: JiraIssue) -> list[TextareaCollapsible]:
-        widgets: list[TextareaCollapsible] = []
+            # build widgets for the fields with rich-text support
+            if self._enable_updating_additional_fields:
+                widgets: list[
+                    ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
+                ] = self._build_textarea_widgets(work_item)
+                for widget in widgets:
+                    if isinstance(widget, Static):
+                        pane_title = widget.name
+                        pane_id = f'pane-{widget.id}'
+                    else:
+                        pane_title = widget.field_title
+                        pane_id = f'pane-{widget.jira_field_key}'
+
+                    pane = TextAreaTabPane(title=pane_title, widget_id=pane_id)
+                    await self.info_tabbed_content.add_pane(pane)
+                    await pane.mount(widget)
+
+    def _build_textarea_widgets(
+        self,
+        work_item: JiraIssue,
+    ) -> list[ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static]:
+        widgets: list[
+            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
+        ] = []
         if issue_edit_metadata := work_item.get_edit_metadata():
             ignored_fields = self._update_additional_fields_ignore_ids
             for field_id, field in issue_edit_metadata.items():
@@ -378,17 +426,19 @@ class WorkItemInfoContainer(Vertical):
                     metadata.key and metadata.key.lower() == JiraWorkItemFields.ENVIRONMENT.value
                 ):
                     field_name = metadata.name or metadata.key.replace('_', ' ').title()
-                    widget_for_collapsible: (
+                    textarea_widget: (
                         ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
                     )
                     if metadata.key.lower() == JiraWorkItemFields.ENVIRONMENT.value:
                         if work_item.rich_text_value_is_empty(work_item.environment):  # type:ignore[arg-type]
-                            widget_for_collapsible = Static(
-                                f'There is no "{field_name}" set. Press "e" to edit it.',
+                            textarea_widget = Static(
+                                f'There is no "{field_name}" set. Press "^e" to edit it.',
                                 classes='tip',
+                                id=metadata.key,
+                                name=field_name,
                             )
                         else:
-                            widget_for_collapsible = build_read_only_rich_text_widget(
+                            textarea_widget = build_read_only_rich_text_widget(
                                 jira_field_key=metadata.key,
                                 field_name=field_name,
                                 required=metadata.required,
@@ -398,36 +448,37 @@ class WorkItemInfoContainer(Vertical):
                         # get the value of the field
                         field_value: Any | None = work_item.get_custom_field_value(field_id)
                         if work_item.rich_text_value_is_empty(field_value):
-                            widget_for_collapsible = Static(
-                                f'There is no "{field_name}" set. Press "e" to edit it.',
+                            textarea_widget = Static(
+                                f'There is no "{field_name}" set. Press "^e" to edit it.',
                                 classes='tip',
+                                id=metadata.key,
+                                name=field_name,
                             )
                         else:
-                            widget_for_collapsible = build_read_only_rich_text_widget(
+                            textarea_widget = build_read_only_rich_text_widget(
                                 jira_field_key=metadata.key,
                                 field_name=field_name,
                                 required=metadata.required,
                                 content=field_value,
                             )
 
-                    widgets.append(
-                        TextareaCollapsible(
-                            jira_field_key=metadata.key,
-                            widget=widget_for_collapsible,
-                            field_name=field_name,
-                            required=metadata.required,
-                            collapsed=True,
-                        )
-                    )
+                    widgets.append(textarea_widget)
         return widgets
 
     def watch_clear_information(self, clear: bool = False) -> None:
         if clear:
-            # reset the value of the summary and hide the widget
-            self.issue_summary_widget.update('')
-            self.issue_summary_widget.visible = False
-            self.collapsible_container.remove_children()
-            self.query_one(Rule).visible = False
+            self._clear_static_widgets()
+            self.run_worker(self._clear_dynamic_tabs)
+
+    async def _clear_dynamic_tabs(self) -> None:
+        info_tabbed_content: InfoTabbedContent | None = self.query_one_optional(
+            '#info-tabbed-content', expect_type=InfoTabbedContent
+        )
+        if info_tabbed_content is not None:
+            # remove all existing TextAreaTabPane children
+            await info_tabbed_content.query(TextAreaTabPane).remove()
+            # remove the tabbed content widget
+            await info_tabbed_content.remove()
 
     def show_loading(self) -> None:
         """Shows the loading indicator and hides content."""

--- a/src/jiratui/widgets/work_item_info/info.py
+++ b/src/jiratui/widgets/work_item_info/info.py
@@ -36,10 +36,10 @@ from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget
 class TextareaCollapsible(Collapsible):
     BINDINGS = [
         Binding(
-            key='e',
+            key='ctrl+e',
             action='edit_content',
             description='Edit',
-            key_display='e',
+            key_display='^e',
         ),
         Binding(
             key='v',

--- a/src/jiratui/widgets/work_item_info/info.py
+++ b/src/jiratui/widgets/work_item_info/info.py
@@ -6,22 +6,13 @@ from typing import Any, cast
 
 from textual import on
 from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import Center, ItemGrid, Vertical, VerticalGroup, VerticalScroll
-from textual.css.query import NoMatches
+from textual.containers import Center, Vertical, VerticalGroup, VerticalScroll
 from textual.message import Message
 from textual.reactive import Reactive, reactive
-from textual.screen import ModalScreen, Screen
 from textual.widgets import (
-    Button,
-    Footer,
     LoadingIndicator,
-    MarkdownViewer,
     Rule,
     Static,
-    TabbedContent,
-    TabPane,
-    TextArea,
 )
 
 from jiratui.api_controller.controller import APIControllerResponse
@@ -34,182 +25,8 @@ from jiratui.widgets.commons.factory_utils import (
     build_read_only_rich_text_widget,
 )
 from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget
-
-
-class DisplayTextContentScreen(ModalScreen):
-    BINDINGS = [('escape', 'app.pop_screen', 'Close')]
-
-    def __init__(self, content: str, title: str | None = None):
-        super().__init__()
-        self.__content = content
-        self.title = title
-
-    def compose(self) -> ComposeResult:
-        yield MarkdownViewer(self.__content)
-
-
-class EditTextContentScreen(Screen[dict]):
-    """A modal screen that displays a TextArea editor to allow users to edit Plain Text/Markdown content."""
-
-    BINDINGS = [
-        Binding('escape', 'app.pop_screen', 'Close'),
-        Binding('ctrl+s', 'save_content', 'Save', show=True, key_display='^s'),
-    ]
-
-    def __init__(self, content: str, jira_field_key: str, title: str | None = None):
-        super().__init__()
-        self.__content: str = content
-        self.__jira_field_key = jira_field_key
-        self.title = title
-
-    @property
-    def textarea(self) -> TextArea:
-        return self.query_one(TextArea)
-
-    def compose(self) -> ComposeResult:
-        with Vertical():
-            widget = TextArea.code_editor(
-                self.__content,
-                language='markdown',
-                show_line_numbers=False,
-                compact=True,
-                theme='css',
-            )
-            widget.border_title = self.title
-            yield widget
-            with ItemGrid(classes='edit-grid-buttons'):
-                yield Button(
-                    'Save',
-                    variant='success',
-                    id='edit-description-button-save',
-                    classes='save-cancel-buttons',
-                )
-                yield Button(
-                    'Cancel',
-                    variant='error',
-                    id='edit-description-button-quit',
-                    classes='save-cancel-buttons',
-                )
-            yield Static()
-        yield Footer(compact=True, show_command_palette=False)
-
-    def on_mount(self):
-        self.post_message(TextArea.Changed(self.query_one(TextArea)))
-
-    def save_button(self) -> Button:
-        return self.query_one('#edit-description-button-save', Button)
-
-    @on(Button.Pressed, '#edit-description-button-quit')
-    def handle_cancel(self) -> None:
-        self.dismiss({})
-
-    @on(Button.Pressed, '#edit-description-button-save')
-    def handle_save(self) -> None:
-        self.dismiss(
-            {'content': self.textarea.text.strip(), 'jira_field_key': self.__jira_field_key}
-        )
-
-    def action_save_content(self) -> None:
-        self.handle_save()
-
-
-class TextAreaTabPane(TabPane):
-    """A custom TabPane that contains either ReadOnlyADFMarkdownTextAreaWidget or ReadOnlyPlainTextTextAreaWidget as
-    its child."""
-
-    def __init__(self, title: str, widget_id: str, **kwargs):
-        super().__init__(title=title, id=widget_id, **kwargs)
-
-
-class InfoTabbedContent(TabbedContent):
-    """Custom TabbedContent with key bindings for editing, viewing and copying the content of the currently active
-    pane/tab."""
-
-    BINDINGS = [
-        Binding(
-            key='ctrl+e', action='edit_content', description='Edit', show=True, key_display='^e'
-        ),
-        Binding(key='v', action='view_content', description='View', key_display='v'),
-        Binding(key='c', action='copy_content', description='Copy', key_display='c'),
-    ]
-
-    class DisplayContent(Message):
-        def __init__(self, content: str, title: str | None = None):
-            super().__init__()
-            self.content = content
-            self.title = title
-
-    class EditContent(Message):
-        def __init__(
-            self, jira_field_key: str, content: str | None = None, title: str | None = None
-        ):
-            super().__init__()
-            self.content = content or ''
-            self.jira_field_key = jira_field_key
-            self.title = title
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def _get_textarea_widget(
-        self,
-    ) -> ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None:
-        if (active_pane := self.active_pane) is None:
-            return None
-        try:
-            return active_pane.query_one(ReadOnlyADFMarkdownTextAreaWidget)
-        except NoMatches:
-            try:
-                return active_pane.query_one(ReadOnlyPlainTextTextAreaWidget)
-            except NoMatches:
-                try:
-                    return active_pane.query_one(Static)
-                except NoMatches:
-                    return None
-
-    def action_edit_content(self) -> None:
-        """Sends an `InfoTabbedContent.EditContent` message to the parent to edit the content of the active pane's
-        widget."""
-
-        widget: (
-            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
-        ) = self._get_textarea_widget()
-        if widget is not None:
-            if isinstance(widget, Static):
-                content_to_edit = ''
-                jira_field_key = widget.id
-                title = widget.name
-            else:
-                content_to_edit = widget.text_content
-                jira_field_key = widget.jira_field_key
-                title = widget.field_title
-            self.post_message(self.EditContent(jira_field_key, content_to_edit, title))
-
-    def action_view_content(self) -> None:
-        """Sends an `InfoTabbedContent.DisplayContent` message to the parent to view the content of the active
-        pane's widget."""
-
-        widget: (
-            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
-        ) = self._get_textarea_widget()
-        if widget is not None:
-            if isinstance(widget, Static):
-                self.notify(f'The field {widget.name} has no content. Press "^e" to edit it.')
-            else:
-                self.post_message(self.DisplayContent(widget.text_content, widget.field_title))
-
-    def action_copy_content(self) -> None:
-        """Copy to the clipboard the content of the field."""
-
-        widget: (
-            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
-        ) = self._get_textarea_widget()
-        if widget is not None:
-            if isinstance(widget, Static):
-                self.notify(f'The field {widget.name} has no content. Press "^e" to edit it.')
-            else:
-                self.app.copy_to_clipboard(widget.text_content.strip())
-                self.notify('Content copied!')
+from jiratui.widgets.work_item_info.screens import DisplayTextContentScreen, EditTextContentScreen
+from jiratui.widgets.work_item_info.tabs import InfoTabbedContent, TextAreaTabPane
 
 
 class WorkItemInfoContainer(Vertical):

--- a/src/jiratui/widgets/work_item_info/screens.py
+++ b/src/jiratui/widgets/work_item_info/screens.py
@@ -1,0 +1,83 @@
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import ItemGrid, Vertical
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Button, Footer, MarkdownViewer, Static, TextArea
+
+
+class EditTextContentScreen(Screen[dict]):
+    """A modal screen that displays a TextArea editor to allow users to edit Plain Text/Markdown content."""
+
+    BINDINGS = [
+        Binding('escape', 'app.pop_screen', 'Close'),
+        Binding('ctrl+s', 'save_content', 'Save', show=True, key_display='^s'),
+    ]
+
+    def __init__(self, content: str, jira_field_key: str, title: str | None = None):
+        super().__init__()
+        self.__content: str = content
+        self.__jira_field_key = jira_field_key
+        self.title = title
+
+    @property
+    def textarea(self) -> TextArea:
+        return self.query_one(TextArea)
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            widget = TextArea.code_editor(
+                self.__content,
+                language='markdown',
+                show_line_numbers=False,
+                compact=True,
+                theme='css',
+            )
+            widget.border_title = self.title
+            yield widget
+            with ItemGrid(classes='edit-grid-buttons'):
+                yield Button(
+                    'Save',
+                    variant='success',
+                    id='edit-description-button-save',
+                    classes='save-cancel-buttons',
+                )
+                yield Button(
+                    'Cancel',
+                    variant='error',
+                    id='edit-description-button-quit',
+                    classes='save-cancel-buttons',
+                )
+            yield Static()
+        yield Footer(compact=True, show_command_palette=False)
+
+    def on_mount(self):
+        self.post_message(TextArea.Changed(self.query_one(TextArea)))
+
+    def save_button(self) -> Button:
+        return self.query_one('#edit-description-button-save', Button)
+
+    @on(Button.Pressed, '#edit-description-button-quit')
+    def handle_cancel(self) -> None:
+        self.dismiss({})
+
+    @on(Button.Pressed, '#edit-description-button-save')
+    def handle_save(self) -> None:
+        self.dismiss(
+            {'content': self.textarea.text.strip(), 'jira_field_key': self.__jira_field_key}
+        )
+
+    def action_save_content(self) -> None:
+        self.handle_save()
+
+
+class DisplayTextContentScreen(ModalScreen):
+    BINDINGS = [('escape', 'app.pop_screen', 'Close')]
+
+    def __init__(self, content: str, title: str | None = None):
+        super().__init__()
+        self.__content = content
+        self.title = title
+
+    def compose(self) -> ComposeResult:
+        yield MarkdownViewer(self.__content)

--- a/src/jiratui/widgets/work_item_info/tabs.py
+++ b/src/jiratui/widgets/work_item_info/tabs.py
@@ -1,0 +1,106 @@
+from textual.binding import Binding
+from textual.css.query import NoMatches
+from textual.message import Message
+from textual.widgets import Static, TabbedContent, TabPane
+
+from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
+from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget
+
+
+class InfoTabbedContent(TabbedContent):
+    """Custom TabbedContent with key bindings for editing, viewing and copying the content of the currently active
+    pane/tab."""
+
+    BINDINGS = [
+        Binding(
+            key='ctrl+e', action='edit_content', description='Edit', show=True, key_display='^e'
+        ),
+        Binding(key='v', action='view_content', description='View', key_display='v'),
+        Binding(key='c', action='copy_content', description='Copy', key_display='c'),
+    ]
+
+    class DisplayContent(Message):
+        def __init__(self, content: str, title: str | None = None):
+            super().__init__()
+            self.content = content
+            self.title = title
+
+    class EditContent(Message):
+        def __init__(
+            self, jira_field_key: str, content: str | None = None, title: str | None = None
+        ):
+            super().__init__()
+            self.content = content or ''
+            self.jira_field_key = jira_field_key
+            self.title = title
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _get_textarea_widget(
+        self,
+    ) -> ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None:
+        if (active_pane := self.active_pane) is None:
+            return None
+        try:
+            return active_pane.query_one(ReadOnlyADFMarkdownTextAreaWidget)
+        except NoMatches:
+            try:
+                return active_pane.query_one(ReadOnlyPlainTextTextAreaWidget)
+            except NoMatches:
+                try:
+                    return active_pane.query_one(Static)
+                except NoMatches:
+                    return None
+
+    def action_edit_content(self) -> None:
+        """Sends an `InfoTabbedContent.EditContent` message to the parent to edit the content of the active pane's
+        widget."""
+
+        widget: (
+            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+        ) = self._get_textarea_widget()
+        if widget is not None:
+            if isinstance(widget, Static):
+                content_to_edit = ''
+                jira_field_key = widget.id
+                title = widget.name
+            else:
+                content_to_edit = widget.text_content
+                jira_field_key = widget.jira_field_key
+                title = widget.field_title
+            self.post_message(self.EditContent(jira_field_key, content_to_edit, title))
+
+    def action_view_content(self) -> None:
+        """Sends an `InfoTabbedContent.DisplayContent` message to the parent to view the content of the active
+        pane's widget."""
+
+        widget: (
+            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+        ) = self._get_textarea_widget()
+        if widget is not None:
+            if isinstance(widget, Static):
+                self.notify(f'The field {widget.name} has no content. Press "^e" to edit it.')
+            else:
+                self.post_message(self.DisplayContent(widget.text_content, widget.field_title))
+
+    def action_copy_content(self) -> None:
+        """Copy to the clipboard the content of the field."""
+
+        widget: (
+            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+        ) = self._get_textarea_widget()
+        if widget is not None:
+            if isinstance(widget, Static):
+                self.notify(f'The field {widget.name} has no content. Press "^e" to edit it.')
+            else:
+                self.app.copy_to_clipboard(widget.text_content.strip())
+                self.notify('Content copied!')
+
+
+class TextAreaTabPane(TabPane):
+    """A custom TabPane that contains either ReadOnlyADFMarkdownTextAreaWidget or ReadOnlyPlainTextTextAreaWidget as
+    its child."""
+
+    def __init__(self, title: str, widget_id: str, **kwargs):
+        super().__init__(title=title, id=widget_id, **kwargs)

--- a/src/jiratui/widgets/work_item_info/tests/test_info.py
+++ b/src/jiratui/widgets/work_item_info/tests/test_info.py
@@ -8,10 +8,9 @@ from jiratui.models import JiraIssue
 from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
 from jiratui.widgets.commons.factory_utils import build_read_only_rich_text_widget
 from jiratui.widgets.work_item_info.info import (
-    InfoTabbedContent,
-    TextAreaTabPane,
     WorkItemInfoContainer,
 )
+from jiratui.widgets.work_item_info.tabs import InfoTabbedContent, TextAreaTabPane
 
 
 @pytest.mark.asyncio

--- a/src/jiratui/widgets/work_item_info/tests/test_info.py
+++ b/src/jiratui/widgets/work_item_info/tests/test_info.py
@@ -1,12 +1,15 @@
 from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
-from textual.widgets import Rule
+from textual.widgets import Rule, Static
 
 from jiratui.app import JiraApp
+from jiratui.models import JiraIssue
 from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
+from jiratui.widgets.commons.factory_utils import build_read_only_rich_text_widget
 from jiratui.widgets.work_item_info.info import (
-    TextareaCollapsible,
+    InfoTabbedContent,
+    TextAreaTabPane,
     WorkItemInfoContainer,
 )
 
@@ -23,18 +26,33 @@ async def test_work_item_info_container_with_summary_description_only(
                 'key': 'description',
                 'name': 'description',
                 'required': True,
-            }
+            },
         }
     }
-    async with app.run_test():
+    jira_issues_with_custom_fields[0].description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    async with app.run_test() as pilot:
         widget = WorkItemInfoContainer()
         await app.screen.mount(widget)
+        await app.workers.wait_for_complete()
         # WHEN
         widget.issue = jira_issues_with_custom_fields[0]
         await app.workers.wait_for_complete()
+        await pilot.pause()
         assert widget.issue_summary_widget.content == 'abcd'
         assert widget.query_one(Rule).visible is True
-        assert len(widget.collapsible_container.children) == 1
+        assert isinstance(widget.info_tabbed_content, InfoTabbedContent)
+        tab_panes = widget.info_tabbed_content.query(TextAreaTabPane)
+        assert len(tab_panes) == 1
+        assert isinstance(tab_panes[0], TextAreaTabPane)
+        assert tab_panes[0].id == 'pane-description'
+        assert isinstance(tab_panes[0].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert tab_panes[0].children[0].border_title == 'Description'
+        assert tab_panes[0].children[0].border_subtitle == '(*)'
+        assert tab_panes[0].children[0].jira_field_key == 'description'
 
 
 @patch.object(
@@ -44,7 +62,7 @@ async def test_work_item_info_container_with_summary_description_only(
     WorkItemInfoContainer, '_enable_updating_additional_fields', PropertyMock(return_value=True)
 )
 @pytest.mark.asyncio
-async def test_work_item_info_container_updating_additional_fields_enable(
+async def test_work_item_info_container_updating_additional_fields_enabled(
     jira_issues_with_custom_fields,
     app,
 ):
@@ -62,23 +80,51 @@ async def test_work_item_info_container_updating_additional_fields_enable(
                 'name': 'environment',
                 'required': True,
             },
+            'field_a': {
+                'schema': {'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:textarea'},
+                'key': 'field_a',
+                'name': 'Field A',
+                'required': False,
+            },
         }
     }
-    async with app.run_test():
+    jira_issues_with_custom_fields[0].description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    jira_issues_with_custom_fields[0].environment = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Goodbye world!'}]}],
+    }
+    async with app.run_test() as pilot:
         widget = WorkItemInfoContainer()
-
         await app.screen.mount(widget)
+        await app.workers.wait_for_complete()
         # WHEN
         widget.issue = jira_issues_with_custom_fields[0]
         await app.workers.wait_for_complete()
+        await pilot.pause()
         assert widget.issue_summary_widget.content == 'abcd'
         assert widget.query_one(Rule).visible is True
-        assert len(widget.collapsible_container.children) == 2
-        assert isinstance(widget.collapsible_container.children[0], TextareaCollapsible)
-        assert isinstance(widget.collapsible_container.children[1], TextareaCollapsible)
-        keys = [w._jira_field_key for w in widget.collapsible_container.children]
-        assert 'environment' in keys
-        assert 'description' in keys
+        assert isinstance(widget.info_tabbed_content, InfoTabbedContent)
+        tab_panes = widget.info_tabbed_content.query(TextAreaTabPane)
+        assert len(tab_panes) == 3
+        assert isinstance(tab_panes[0], TextAreaTabPane)
+        assert isinstance(tab_panes[1], TextAreaTabPane)
+        assert isinstance(tab_panes[2], TextAreaTabPane)
+        assert tab_panes[0].id == 'pane-description'
+        assert tab_panes[1].id == 'pane-environment'
+        assert isinstance(tab_panes[0].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert isinstance(tab_panes[1].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert isinstance(tab_panes[2].children[0], Static)
+        assert tab_panes[0].children[0].border_title == 'Description'
+        assert tab_panes[0].children[0].border_subtitle == '(*)'
+        assert tab_panes[0].children[0].jira_field_key == 'description'
+        assert tab_panes[1].children[0].border_title == 'environment'
+        assert tab_panes[1].children[0].border_subtitle == '(*)'
+        assert tab_panes[1].children[0].jira_field_key == 'environment'
 
 
 @patch.object(
@@ -108,20 +154,35 @@ async def test_work_item_info_container_updating_additional_fields_disabled(
             },
         }
     }
-    async with app.run_test():
+    jira_issues_with_custom_fields[0].description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    jira_issues_with_custom_fields[0].environment = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Goodbye world!'}]}],
+    }
+    async with app.run_test() as pilot:
         widget = WorkItemInfoContainer()
-
         await app.screen.mount(widget)
+        await app.workers.wait_for_complete()
         # WHEN
         widget.issue = jira_issues_with_custom_fields[0]
         await app.workers.wait_for_complete()
+        await pilot.pause()
         assert widget.issue_summary_widget.content == 'abcd'
         assert widget.query_one(Rule).visible is True
-        assert len(widget.collapsible_container.children) == 1
-        assert isinstance(widget.collapsible_container.children[0], TextareaCollapsible)
-        keys = [w._jira_field_key for w in widget.collapsible_container.children]
-        assert 'description' in keys
-        assert 'environment' not in keys
+        assert isinstance(widget.info_tabbed_content, InfoTabbedContent)
+        tab_panes = widget.info_tabbed_content.query(TextAreaTabPane)
+        assert len(tab_panes) == 1
+        assert isinstance(tab_panes[0], TextAreaTabPane)
+        assert tab_panes[0].id == 'pane-description'
+        assert isinstance(tab_panes[0].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert tab_panes[0].children[0].border_title == 'Description'
+        assert tab_panes[0].children[0].border_subtitle == '(*)'
+        assert tab_panes[0].children[0].jira_field_key == 'description'
 
 
 @patch.object(
@@ -153,20 +214,35 @@ async def test_work_item_info_container_updating_additional_fields_enabled_with_
             },
         }
     }
-    async with app.run_test():
+    jira_issues_with_custom_fields[0].description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    jira_issues_with_custom_fields[0].environment = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Goodbye world!'}]}],
+    }
+    async with app.run_test() as pilot:
         widget = WorkItemInfoContainer()
-
         await app.screen.mount(widget)
+        await app.workers.wait_for_complete()
         # WHEN
         widget.issue = jira_issues_with_custom_fields[0]
         await app.workers.wait_for_complete()
+        await pilot.pause()
         assert widget.issue_summary_widget.content == 'abcd'
         assert widget.query_one(Rule).visible is True
-        assert len(widget.collapsible_container.children) == 1
-        assert isinstance(widget.collapsible_container.children[0], TextareaCollapsible)
-        keys = [w._jira_field_key for w in widget.collapsible_container.children]
-        assert 'description' in keys
-        assert 'environment' not in keys
+        assert isinstance(widget.info_tabbed_content, InfoTabbedContent)
+        tab_panes = widget.info_tabbed_content.query(TextAreaTabPane)
+        assert len(tab_panes) == 1
+        assert isinstance(tab_panes[0], TextAreaTabPane)
+        assert tab_panes[0].id == 'pane-description'
+        assert isinstance(tab_panes[0].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert tab_panes[0].children[0].border_title == 'Description'
+        assert tab_panes[0].children[0].border_subtitle == '(*)'
+        assert tab_panes[0].children[0].jira_field_key == 'description'
 
 
 @patch.object(
@@ -202,52 +278,78 @@ async def test_work_item_info_container_updating_additional_fields_enable_with_t
             },
         }
     }
-    async with app.run_test():
+    jira_issues_with_custom_fields[0].description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    jira_issues_with_custom_fields[0].environment = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Goodbye world!'}]}],
+    }
+    async with app.run_test() as pilot:
         widget = WorkItemInfoContainer()
         await app.screen.mount(widget)
+        await app.workers.wait_for_complete()
         # WHEN
         widget.issue = jira_issues_with_custom_fields[0]
         await app.workers.wait_for_complete()
+        await pilot.pause()
         assert widget.issue_summary_widget.content == 'abcd'
         assert widget.query_one(Rule).visible is True
-        assert len(widget.collapsible_container.children) == 3
-        assert isinstance(widget.collapsible_container.children[0], TextareaCollapsible)
-        assert isinstance(widget.collapsible_container.children[1], TextareaCollapsible)
-        assert isinstance(widget.collapsible_container.children[2], TextareaCollapsible)
-        keys = [w._jira_field_key for w in widget.collapsible_container.children]
-        assert 'environment' in keys
-        assert 'description' in keys
-        assert 'field_a' in keys
-        assert widget.collapsible_container.children[2].border_subtitle == '(*)'
-        assert widget.collapsible_container.children[1].border_subtitle is None
+        assert isinstance(widget.info_tabbed_content, InfoTabbedContent)
+        tab_panes = widget.info_tabbed_content.query(TextAreaTabPane)
+        assert len(tab_panes) == 3
+        assert isinstance(tab_panes[0], TextAreaTabPane)
+        assert isinstance(tab_panes[1], TextAreaTabPane)
+        assert isinstance(tab_panes[2], TextAreaTabPane)
+        assert tab_panes[0].id == 'pane-description'
+        assert tab_panes[1].id == 'pane-environment'
+        assert tab_panes[2].id == 'pane-field_a'
+        assert isinstance(tab_panes[0].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert isinstance(tab_panes[1].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert isinstance(tab_panes[2].children[0], Static)
+        assert tab_panes[0].children[0].border_title == 'Description'
+        assert tab_panes[0].children[0].border_subtitle == '(*)'
+        assert tab_panes[0].children[0].jira_field_key == 'description'
+        assert tab_panes[1].children[0].border_title == 'environment'
+        assert tab_panes[1].children[0].border_subtitle == '(*)'
+        assert tab_panes[1].children[0].jira_field_key == 'environment'
+        assert tab_panes[2].children[0].id == 'field_a'
 
 
 @pytest.mark.asyncio
 async def test_work_item_info_container_with_view_content(app):
-    # GIVEN
     async with app.run_test() as pilot:
-        widget = TextareaCollapsible(
-            'description',
-            'description',
-            ReadOnlyADFMarkdownTextAreaWidget(
+        # GIVEN
+        widget = InfoTabbedContent()
+        await app.screen.mount(widget)
+        await pilot.pause()
+        pane = TextAreaTabPane(title='Description', widget_id='pane-description')
+        await widget.add_pane(pane)
+        await pane.mount(
+            build_read_only_rich_text_widget(
                 jira_field_key='description',
-                field_id='description',
-                original_value={
+                field_name='Description',
+                required=False,
+                content={
                     'type': 'doc',
                     'version': 1,
                     'content': [
-                        {'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world'}]}
+                        {'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}
                     ],
                 },
-            ),
+            )
         )
-        await app.screen.mount(widget)
-        await pilot.pause()
         # WHEN
         widget.action_view_content()
         # THEN
-        assert isinstance(widget.widget, ReadOnlyADFMarkdownTextAreaWidget)
-        assert widget.text_content == 'Hello world\n'
+        assert isinstance(widget.active_pane, TextAreaTabPane)
+        assert (
+            widget.active_pane.query_one(ReadOnlyADFMarkdownTextAreaWidget).text_content
+            == 'Hello world!\n'
+        )
 
 
 @patch.object(JiraApp, 'copy_to_clipboard')
@@ -255,24 +357,311 @@ async def test_work_item_info_container_with_view_content(app):
 async def test_copy_content_to_clipboard(copy_to_clipboard_mock: Mock, app):
     async with app.run_test() as pilot:
         # GIVEN
-        widget = TextareaCollapsible(
-            'description',
-            'description',
-            ReadOnlyADFMarkdownTextAreaWidget(
+        widget = InfoTabbedContent()
+        await app.screen.mount(widget)
+        await pilot.pause()
+        pane = TextAreaTabPane(title='Description', widget_id='pane-description')
+        await widget.add_pane(pane)
+        await pane.mount(
+            build_read_only_rich_text_widget(
                 jira_field_key='description',
-                field_id='description',
-                original_value={
+                field_name='Description',
+                required=False,
+                content={
                     'type': 'doc',
                     'version': 1,
                     'content': [
-                        {'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world'}]}
+                        {'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}
                     ],
                 },
-            ),
+            )
         )
-        await app.screen.mount(widget)
-        await pilot.pause()
         # WHEN
         widget.action_copy_content()
         # THEN
-        copy_to_clipboard_mock.assert_called_once_with('Hello world')
+        copy_to_clipboard_mock.assert_called_once_with('Hello world!')
+
+
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_without_edit_metadata(jira_issues_with_custom_fields, app):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {}
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert widgets == []
+
+
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_without_edit_metadata_fields(
+    jira_issues_with_custom_fields, app
+):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {'fields': {}}
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert widgets == []
+
+
+@patch.object(
+    WorkItemInfoContainer,
+    '_update_additional_fields_ignore_ids',
+    PropertyMock(return_value=['field_a']),
+)
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_with_ignored_fields(jira_issues_with_custom_fields, app):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {'fields': {'field_a': {'key': 'field_a'}}}
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert widgets == []
+
+
+@patch.object(
+    WorkItemInfoContainer, '_update_additional_fields_ignore_ids', PropertyMock(return_value=[])
+)
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_skip_description(jira_issues_with_custom_fields, app):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {'description': {'key': 'description'}}
+    }
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert widgets == []
+
+
+@patch.object(
+    WorkItemInfoContainer, '_update_additional_fields_ignore_ids', PropertyMock(return_value=[])
+)
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_skip_fields_without_schema(
+    jira_issues_with_custom_fields, app
+):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {'fields': {'field_a': {'key': 'field_a'}}}
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert widgets == []
+
+
+@patch.object(
+    WorkItemInfoContainer, '_update_additional_fields_ignore_ids', PropertyMock(return_value=[])
+)
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_skip_fields_with_non_textarea_schema(
+    jira_issues_with_custom_fields, app
+):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {'field_a': {'key': 'field_a', 'schema': {'custom': 'custom-type'}}}
+    }
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert widgets == []
+
+
+@patch.object(JiraIssue, 'get_custom_field_value')
+@patch.object(
+    WorkItemInfoContainer, '_update_additional_fields_ignore_ids', PropertyMock(return_value=[])
+)
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_with_empty_field_value_generates_static(
+    get_custom_field_value_mock: Mock, jira_issues_with_custom_fields, app
+):
+    # GIVEN
+    get_custom_field_value_mock.return_value = ''
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {
+            'field_a': {
+                'key': 'field_a',
+                'schema': {'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:textarea'},
+            }
+        }
+    }
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert isinstance(widgets[0], Static)
+        assert len(widgets) == 1
+        assert widgets[0].id == 'field_a'
+        assert widgets[0].name == 'Field A'
+
+
+@patch('jiratui.widgets.work_item_info.info.build_read_only_rich_text_widget')
+@patch.object(JiraIssue, 'get_custom_field_value')
+@patch.object(
+    WorkItemInfoContainer, '_update_additional_fields_ignore_ids', PropertyMock(return_value=[])
+)
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_with_non_empty_field_value_generates_adf_widget(
+    get_custom_field_value_mock: Mock,
+    build_read_only_rich_text_widget_mock: Mock,
+    jira_issues_with_custom_fields,
+    app,
+):
+    # GIVEN
+    get_custom_field_value_mock.return_value = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    build_read_only_rich_text_widget_mock.return_value = ReadOnlyADFMarkdownTextAreaWidget(
+        jira_field_key='field_a',
+        field_id='field_a',
+        title='Field A',
+    )
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {
+            'field_a': {
+                'key': 'field_a',
+                'schema': {'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:textarea'},
+            }
+        }
+    }
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert isinstance(widgets[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert len(widgets) == 1
+        assert widgets[0].id == 'field_a'
+        assert widgets[0].jira_field_key == 'field_a'
+        assert widgets[0].field_title == 'Field A'
+
+
+@patch.object(JiraIssue, 'get_custom_field_value')
+@patch.object(
+    WorkItemInfoContainer, '_update_additional_fields_ignore_ids', PropertyMock(return_value=[])
+)
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_with_empty_environment_field_value_generates_static(
+    get_custom_field_value_mock: Mock, jira_issues_with_custom_fields, app
+):
+    # GIVEN
+    get_custom_field_value_mock.return_value = ''
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {'environment': {'key': 'environment', 'schema': {'custom': 'custom-type'}}}
+    }
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert isinstance(widgets[0], Static)
+        assert len(widgets) == 1
+        assert widgets[0].id == 'environment'
+        assert widgets[0].name == 'Environment'
+
+
+@patch('jiratui.widgets.work_item_info.info.build_read_only_rich_text_widget')
+@patch.object(
+    WorkItemInfoContainer, '_update_additional_fields_ignore_ids', PropertyMock(return_value=[])
+)
+@pytest.mark.asyncio
+async def test_build_textarea_widgets_with_non_empty_environment_field_value_generates_adf_widget(
+    build_read_only_rich_text_widget_mock: Mock, jira_issues_with_custom_fields, app
+):
+    # GIVEN
+    jira_issues_with_custom_fields[0].environment = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    build_read_only_rich_text_widget_mock.return_value = ReadOnlyADFMarkdownTextAreaWidget(
+        jira_field_key='environment',
+        field_id='environment',
+        title='environment',
+    )
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {'environment': {'key': 'environment', 'schema': {'custom': 'custom-type'}}}
+    }
+    async with app.run_test():
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        # WHEN
+        widgets = widget._build_textarea_widgets(jira_issues_with_custom_fields[0])
+        # THEN
+        assert isinstance(widgets[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert len(widgets) == 1
+        assert widgets[0].id == 'environment'
+        assert widgets[0].jira_field_key == 'environment'
+        assert widgets[0].field_title == 'environment'
+
+
+@pytest.mark.asyncio
+async def test_work_item_info_container_clear_information(
+    jira_issues_with_custom_fields,
+    app,
+):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {
+            'description': {
+                'key': 'description',
+                'name': 'description',
+                'required': True,
+            },
+        }
+    }
+    jira_issues_with_custom_fields[0].description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    async with app.run_test() as pilot:
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        await app.workers.wait_for_complete()
+        widget.issue = jira_issues_with_custom_fields[0]
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert widget.issue_summary_widget.content == 'abcd'
+        assert widget.query_one(Rule).visible is True
+        assert isinstance(widget.info_tabbed_content, InfoTabbedContent)
+        tab_panes = widget.info_tabbed_content.query(TextAreaTabPane)
+        assert len(tab_panes) == 1
+        assert isinstance(tab_panes[0], TextAreaTabPane)
+        assert tab_panes[0].id == 'pane-description'
+        assert isinstance(tab_panes[0].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert tab_panes[0].children[0].border_title == 'Description'
+        # WHEN
+        widget.clear_information = True
+        await app.workers.wait_for_complete()
+        # THEN
+        assert widget.issue_summary_widget.content == ''
+        assert widget.issue_summary_widget.visible is False
+        assert widget.query_one(Rule).visible is False
+        assert (
+            widget.query_one_optional('#info-tabbed-content', expect_type=InfoTabbedContent) is None
+        )
+        assert len(widget.tabs_container.children) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "jiratui"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This PR updates the way we display text-based fields inside the Info tab.

Rather than using `Collapsible` we display each field inside a tab. Tabs support 3 keybindings:

- `^e` to open an editor for editing the value of the field
- `v` to open a modal screen that display the full content of the field using a Markdown widget.
- `c` for copying the content of the field (if any) to the clipboard

## Quick view the content of rich-text-based fields in the Info tab

<img width="1502" height="869" alt="Screenshot 2026-05-14 at 18 46 46" src="https://github.com/user-attachments/assets/7c2b3a51-7bab-4999-af4d-d6eaf1628043" />

## Editing the content of rich-text-based fields in the Info tab
<img width="1502" height="869" alt="Screenshot 2026-05-14 at 18 47 04" src="https://github.com/user-attachments/assets/cbc1381f-24a7-47c9-a968-b4bad5fb6245" />

## Viewing the content of rich-text-based fields in the Info tab
<img width="1502" height="869" alt="Screenshot 2026-05-14 at 18 47 31" src="https://github.com/user-attachments/assets/d6c46d1a-aadc-4412-aa55-b91498a6853d" />
