### PR TITLE
JT-32: Fix bug that causes pixelated images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Minor Improvements
 
-- JT-31: Add missing tests by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- JT-31: Add missing tests by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/244
+
+### Bug Fixes
+
+- JT-32: Fix bug that causes pixelated images (https://github.com/whyisdifficult/jiratui/issues/224) by [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/245
 
 ## [1.8.0] - 2026-05-16
 

--- a/src/jiratui/widgets/attachments/attachments.py
+++ b/src/jiratui/widgets/attachments/attachments.py
@@ -12,6 +12,7 @@ from textual.reactive import Reactive, reactive
 from textual.screen import ModalScreen
 from textual.widget import Widget
 from textual.widgets import DataTable, LoadingIndicator, Markdown, Static, TextArea
+from textual_image.widget import Image
 
 from jiratui.api_controller.controller import APIControllerResponse
 from jiratui.config import CONFIGURATION
@@ -436,7 +437,6 @@ class FileAttachmentWidget:
 
         if is_image(file_type) and _image_support_is_enabled():
             from PIL import UnidentifiedImageError
-            from textual_image.widget import Image
 
             try:
                 return Image(BytesIO(content))


### PR DESCRIPTION
This PR fixes a bug that causes images to be rendered pixelated when using [https://github.com/lnqs/textual-image](https://github.com/lnqs/textual-image).

The issue seems to be caused by:

> Note: The process of determining the best available rendering option involves querying the terminal, which means sending and receiving data. Since Textual starts threads to handle input and output, this query will not work once the Textual app has started. Therefore, make sure that textual_image.renderable is imported before running the Textual app (which is typically the case in most use cases).

**make sure that `textual_image.renderable` is imported before running the Textual app**

<img width="1502" height="869" alt="Screenshot 2026-05-17 at 16 50 04" src="https://github.com/user-attachments/assets/ad439682-341a-4a49-8fec-b3964be1c6d9" />

Solves https://github.com/whyisdifficult/jiratui/issues/224
Closes https://github.com/whyisdifficult/jiratui/issues/224
