### PR TITLE
fix: assignee filter not applied when searching with project and assignee

### DIFF
--- a/src/jiratui/widgets/commons/users.py
+++ b/src/jiratui/widgets/commons/users.py
@@ -103,7 +103,7 @@ class JiraUserInput(Input):
     @property
     def account_id(self) -> str | None:
         """This is required to support autocomplete behavior."""
-        return self._account_id if self.value and self.value.strip() else None
+        return self._account_id
 
     @account_id.setter
     def account_id(self, account_id: str | None):


### PR DESCRIPTION
## Problem
The assignee filter was not being applied when searching with both Project and Assignee filters selected.

## Root Cause
The `account_id` property getter in `JiraUserInput` class was returning `None` when the input field's display value (`self.value`) was empty, even when the internal `_account_id` was set. This caused the assignee filter to be ignored during search operations.

## Solution
Removed the dependency on `self.value` in the `account_id` getter, ensuring the stored `account_id` is always returned when set.

## Testing
- Ran 41 tests in `test_main_screen.py` - all passed ✓
- Ran account_id related tests - all passed ✓

## Changes
- Modified `src/jiratui/widgets/commons/users.py:68` to return `self._account_id` directly without checking `self.value`