### PR TITLE
JT-46: Add support for editing work log entries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         args: ['--maxkb=800']
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.14
+    rev: v0.15.20
     hooks:
       # Run the linter.
       - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ versions. By [@whyisdifficult](https://github.com/whyisdifficult) in https://git
 (un)checked first. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/277
 - Set `config.enable_recent_history=True` as default. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/277
 - Set `config.enable_goto=True` as default. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/277
+- Bump `click`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- Bump `pydanticsettings`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- Bump `marklas`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- Bump `pytest`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- Bump `ruff`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
 
 ## [1.9.1] 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for sessions using `ApplicationSession`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/276
 - Add support for remembering the last-used directory when uploading files. This uses `ApplicationSession`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/276
+- Add support for updating worklog entries. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- **DEPRECATED**: pressing `^t` after selecting an item will no longer open the modal to log work for the item. Instead,
+it will open the modal screen that displays the item's work log entries. The keybind `^t` will be removed in future
+versions. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
 
 ### Minor Improvements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,12 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "click>=8.4.1,<9.0.0",
+    "click>=8.4.2,<9.0.0",
     "gitpython>=3.1.47,<3.2.0",
     "httpx>=0.28.1",
-    "marklas==0.8.0",
+    "marklas==0.8.1",
     "puremagic>=2.2.0,<3.0.0",
-    "pydantic-settings[yaml]>=2.14.0,<3.0.0",
+    "pydantic-settings[yaml]>=2.14.2,<3.0.0",
     "python-dateutil>=2.9.0.post0",
     "python-json-logger>=4.1.0,<5.0.0",
     "textual-autocomplete>=4.0.6",
@@ -69,10 +69,10 @@ docs = [
 lint = [
     "import-linter>=2.11",
     "mypy>=2.1.0,<3.0.0",
-    "ruff>=0.15.14,<0.16.0",
+    "ruff>=0.15.20,<0.16.0",
 ]
 test = [
-    "pytest>=9.1.0,<10.0.0",
+    "pytest>=9.1.1,<10.0.0",
     "pytest-asyncio>=1.4.0,<2.0.0",
     "pytest-cov>=7.1.0,<8.0.0",
     "respx>=0.23.1",

--- a/src/jiratui/api/api.py
+++ b/src/jiratui/api/api.py
@@ -1317,6 +1317,58 @@ class JiraAPI:
             params=params,
         )
 
+    async def update_work_log(
+        self,
+        issue_id_or_key: str,
+        worklog_id: str,
+        time_spent: str,
+        started: datetime,
+        time_remaining: str | None = None,
+        comment: str | None = None,
+    ) -> dict:
+        """Updates a worklog from an issue.
+
+        ```{important}
+        Time tracking must be enabled in Jira, otherwise this operation returns an error. For more information, see
+        [Configuring time tracking](https://confluence.atlassian.com/x/qoXKM).
+        ```
+
+        **See Also**:
+        - [api-rest-api-3-issue-issueidorkey-worklog-id-put](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-id-put)
+
+        Args:
+            issue_id_or_key: the ID or key of the issue.
+            worklog_id: the ID of the worklog.
+            comment: a comment about the worklog. Optional when creating or updating a worklog.
+            started: the datetime on which the worklog effort was started. Required when creating a worklog. Optional
+            when updating a worklog.
+            time_spent: the time spent working on the issue as days (#d), hours (#h), or minutes (#m or #). Required
+            when creating a worklog if timeSpentSeconds isn't provided. Optional when updating a worklog. Cannot be
+            provided if timeSpentSecond is provided.
+            time_remaining: the value to set as the issue's remaining time estimate, as days (#d), hours (#h),
+            or minutes (#m or #). For example, 2d. Required when adjustEstimate is new.
+
+        Returns:
+            True if the operation succeeds.
+        """
+
+        payload: dict[str, Any] = {
+            'started': started.isoformat(timespec='milliseconds').replace('+00:00', '+0000'),
+            'timeSpent': time_spent,
+        }
+        if comment and (comment_payload := self._build_worklog_comment_payload(comment)):
+            payload['comment'] = comment_payload
+        params = {'adjustEstimate': 'auto'}
+        if time_remaining:
+            params = {'newEstimate': time_remaining, 'adjustEstimate': 'new'}
+
+        return await self._client.make_request(
+            method=httpx.AsyncClient.put,
+            url=f'issue/{issue_id_or_key}/worklog/{worklog_id}',
+            data=json.dumps(payload),
+            params=params,
+        )
+
     async def delete_work_log(self, issue_id_or_key: str, worklog_id: str) -> bool:
         """Deletes a worklog from an issue.
 
@@ -1753,6 +1805,65 @@ class JiraDataCenterAPI(JiraAPI):
         return await self._client.make_request(  # type:ignore[return-value]
             method=httpx.AsyncClient.post,
             url=f'issue/{issue_id_or_key}/worklog',
+            data=json.dumps(payload),
+            params=params,
+        )
+
+    async def update_work_log(
+        self,
+        issue_id_or_key: str,
+        worklog_id: str,
+        time_spent: str,
+        started: datetime,
+        time_remaining: str | None = None,
+        comment: str | None = None,
+    ) -> dict:
+        """Updates a worklog from an issue.
+
+        ```{important}
+        - Fields possible for editing are: comment, visibility, started, timeSpent and timeSpentSeconds.
+        - Either timeSpent or timeSpentSeconds can be set.
+        - Fields which are not set will not be updated.
+        - For a request to be valid, it has to have at least one field change
+        ```
+
+        ```{important}
+        Time tracking must be enabled in Jira, otherwise this operation returns an error. For more information, see
+        [Configuring time tracking](https://confluence.atlassian.com/x/qoXKM).
+        ```
+
+        **See Also**:
+        - [api-api-2-issue-issueidorkey-worklog-id-put](https://developer.atlassian.com/server/jira/platform/rest/v11001/api-group-issue/#api-api-2-issue-issueidorkey-worklog-id-put)
+
+        Args:
+            issue_id_or_key: the ID or key of the issue.
+            worklog_id: the ID of the worklog.
+            comment: a comment about the worklog. Optional when creating or updating a worklog.
+            started: the datetime on which the worklog effort was started. Required when creating a worklog. Optional
+            when updating a worklog.
+            time_spent: the time spent working on the issue as days (#d), hours (#h), or minutes (#m or #). Required
+            when creating a worklog if timeSpentSeconds isn't provided. Optional when updating a worklog. Cannot be
+            provided if timeSpentSecond is provided.
+            time_remaining: the value to set as the issue's remaining time estimate, as days (#d), hours (#h),
+            or minutes (#m or #). For example, 2d. Required when adjustEstimate is new.
+
+        Returns:
+            True if the operation succeeds.
+        """
+
+        payload: dict[str, Any] = {
+            'started': started.isoformat(timespec='milliseconds').replace('+00:00', '+0000'),
+            'timeSpent': time_spent,
+        }
+        if comment:
+            payload['comment'] = comment
+        params = {'adjustEstimate': 'auto'}
+        if time_remaining:
+            params = {'newEstimate': time_remaining, 'adjustEstimate': 'new'}
+
+        return await self._client.make_request(
+            method=httpx.AsyncClient.put,
+            url=f'issue/{issue_id_or_key}/worklog/{worklog_id}',
             data=json.dumps(payload),
             params=params,
         )

--- a/src/jiratui/api/tests/test_api.py
+++ b/src/jiratui/api/tests/test_api.py
@@ -2470,6 +2470,306 @@ async def test_add_issue_work_log_with_jira_dc_api(jira_api_dc: JiraDataCenterAP
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_update_work_log_with_defaults(jira_api: JiraAPI):
+    # GIVEN
+    route = respx.put(get_url_pattern('issue/1/worklog/2'))
+    route.mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                'author': {
+                    'accountId': '5b10a2844c20165700ede21g',
+                    'active': False,
+                    'displayName': 'Mia Krystof',
+                },
+                'comment': None,
+                'id': '100028',
+                'issueId': '10002',
+                'started': '2021-01-17T12:34:00.000+0000',
+                'timeSpent': '3h 20m',
+                'timeSpentSeconds': 12000,
+                'updateAuthor': {
+                    'accountId': '5b10a2844c20165700ede21g',
+                    'active': False,
+                    'displayName': 'Mia Krystof',
+                },
+                'updated': '2021-01-18T23:45:00.000+0000',
+                'visibility': {
+                    'identifier': '276f955c-63d7-42c8-9520-92d01dca0625',
+                    'type': 'group',
+                    'value': 'jira-developers',
+                },
+            },
+        )
+    )
+    # WHEN
+    started = datetime(2025, 10, 18, 10, 20, tzinfo=timezone.utc)
+    result = await jira_api.update_work_log(
+        '1',
+        '2',
+        '1h',
+        started,
+    )
+    # THEN
+    assert route.calls.last.request.url.path == '/rest/api/3/issue/1/worklog/2'
+    assert 'adjustEstimate=auto' in str(route.calls.last.request.url.query)
+    assert json.loads(route.calls.last.request.content) == {
+        'started': '2025-10-18T10:20:00.000+0000',
+        'timeSpent': '1h',
+    }
+    assert result == {
+        'author': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': False,
+            'displayName': 'Mia Krystof',
+        },
+        'comment': None,
+        'id': '100028',
+        'issueId': '10002',
+        'started': '2021-01-17T12:34:00.000+0000',
+        'timeSpent': '3h 20m',
+        'timeSpentSeconds': 12000,
+        'updateAuthor': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': False,
+            'displayName': 'Mia Krystof',
+        },
+        'updated': '2021-01-18T23:45:00.000+0000',
+        'visibility': {
+            'identifier': '276f955c-63d7-42c8-9520-92d01dca0625',
+            'type': 'group',
+            'value': 'jira-developers',
+        },
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_work_log_with_parameters(jira_api: JiraAPI):
+    # GIVEN
+    route = respx.put(get_url_pattern('issue/1/worklog/2'))
+    route.mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                'author': {
+                    'accountId': '5b10a2844c20165700ede21g',
+                    'active': False,
+                    'displayName': 'Mia Krystof',
+                },
+                'comment': None,
+                'id': '100028',
+                'issueId': '10002',
+                'started': '2021-01-17T12:34:00.000+0000',
+                'timeSpent': '3h 20m',
+                'timeSpentSeconds': 12000,
+                'updateAuthor': {
+                    'accountId': '5b10a2844c20165700ede21g',
+                    'active': False,
+                    'displayName': 'Mia Krystof',
+                },
+                'updated': '2021-01-18T23:45:00.000+0000',
+                'visibility': {
+                    'identifier': '276f955c-63d7-42c8-9520-92d01dca0625',
+                    'type': 'group',
+                    'value': 'jira-developers',
+                },
+            },
+        )
+    )
+    # WHEN
+    started = datetime(2025, 10, 18, 10, 20, tzinfo=timezone.utc)
+    result = await jira_api.update_work_log('1', '2', '1h', started, '1d', 'I did some work')
+    # THEN
+    assert route.calls.last.request.url.path == '/rest/api/3/issue/1/worklog/2'
+    assert 'adjustEstimate=new' in str(route.calls.last.request.url.query)
+    assert 'newEstimate=1d' in str(route.calls.last.request.url.query)
+    assert json.loads(route.calls.last.request.content) == {
+        'started': '2025-10-18T10:20:00.000+0000',
+        'timeSpent': '1h',
+        'comment': {
+            'content': [
+                {'content': [{'text': 'I did some work', 'type': 'text'}], 'type': 'paragraph'}
+            ],
+            'type': 'doc',
+            'version': 1,
+        },
+    }
+    assert result == {
+        'author': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': False,
+            'displayName': 'Mia Krystof',
+        },
+        'comment': None,
+        'id': '100028',
+        'issueId': '10002',
+        'started': '2021-01-17T12:34:00.000+0000',
+        'timeSpent': '3h 20m',
+        'timeSpentSeconds': 12000,
+        'updateAuthor': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': False,
+            'displayName': 'Mia Krystof',
+        },
+        'updated': '2021-01-18T23:45:00.000+0000',
+        'visibility': {
+            'identifier': '276f955c-63d7-42c8-9520-92d01dca0625',
+            'type': 'group',
+            'value': 'jira-developers',
+        },
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_work_log_with_defaults_with_jira_dc_api(jira_api_dc: JiraDataCenterAPI):
+    # GIVEN
+    route = respx.put(get_url_pattern('issue/1/worklog/2'))
+    route.mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                'author': {
+                    'accountId': '5b10a2844c20165700ede21g',
+                    'active': False,
+                    'displayName': 'Mia Krystof',
+                },
+                'comment': None,
+                'id': '100028',
+                'issueId': '10002',
+                'started': '2021-01-17T12:34:00.000+0000',
+                'timeSpent': '3h 20m',
+                'timeSpentSeconds': 12000,
+                'updateAuthor': {
+                    'accountId': '5b10a2844c20165700ede21g',
+                    'active': False,
+                    'displayName': 'Mia Krystof',
+                },
+                'updated': '2021-01-18T23:45:00.000+0000',
+                'visibility': {
+                    'identifier': '276f955c-63d7-42c8-9520-92d01dca0625',
+                    'type': 'group',
+                    'value': 'jira-developers',
+                },
+            },
+        )
+    )
+    # WHEN
+    started = datetime(2025, 10, 18, 10, 20, tzinfo=timezone.utc)
+    result = await jira_api_dc.update_work_log(
+        '1',
+        '2',
+        '1h',
+        started,
+    )
+    # THEN
+    assert route.calls.last.request.url.path == '/rest/api/2/issue/1/worklog/2'
+    assert 'adjustEstimate=auto' in str(route.calls.last.request.url.query)
+    assert json.loads(route.calls.last.request.content) == {
+        'started': '2025-10-18T10:20:00.000+0000',
+        'timeSpent': '1h',
+    }
+    assert result == {
+        'author': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': False,
+            'displayName': 'Mia Krystof',
+        },
+        'comment': None,
+        'id': '100028',
+        'issueId': '10002',
+        'started': '2021-01-17T12:34:00.000+0000',
+        'timeSpent': '3h 20m',
+        'timeSpentSeconds': 12000,
+        'updateAuthor': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': False,
+            'displayName': 'Mia Krystof',
+        },
+        'updated': '2021-01-18T23:45:00.000+0000',
+        'visibility': {
+            'identifier': '276f955c-63d7-42c8-9520-92d01dca0625',
+            'type': 'group',
+            'value': 'jira-developers',
+        },
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_update_work_log_with_parameters_with_jira_dc_api(jira_api_dc: JiraDataCenterAPI):
+    # GIVEN
+    route = respx.put(get_url_pattern('issue/1/worklog/2'))
+    route.mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                'author': {
+                    'accountId': '5b10a2844c20165700ede21g',
+                    'active': False,
+                    'displayName': 'Mia Krystof',
+                },
+                'comment': None,
+                'id': '100028',
+                'issueId': '10002',
+                'started': '2021-01-17T12:34:00.000+0000',
+                'timeSpent': '3h 20m',
+                'timeSpentSeconds': 12000,
+                'updateAuthor': {
+                    'accountId': '5b10a2844c20165700ede21g',
+                    'active': False,
+                    'displayName': 'Mia Krystof',
+                },
+                'updated': '2021-01-18T23:45:00.000+0000',
+                'visibility': {
+                    'identifier': '276f955c-63d7-42c8-9520-92d01dca0625',
+                    'type': 'group',
+                    'value': 'jira-developers',
+                },
+            },
+        )
+    )
+    # WHEN
+    started = datetime(2025, 10, 18, 10, 20, tzinfo=timezone.utc)
+    result = await jira_api_dc.update_work_log('1', '2', '1h', started, '1d', 'I did some work')
+    # THEN
+    assert route.calls.last.request.url.path == '/rest/api/2/issue/1/worklog/2'
+    assert 'adjustEstimate=new' in str(route.calls.last.request.url.query)
+    assert 'newEstimate=1d' in str(route.calls.last.request.url.query)
+    assert json.loads(route.calls.last.request.content) == {
+        'started': '2025-10-18T10:20:00.000+0000',
+        'timeSpent': '1h',
+        'comment': 'I did some work',
+    }
+    assert result == {
+        'author': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': False,
+            'displayName': 'Mia Krystof',
+        },
+        'comment': None,
+        'id': '100028',
+        'issueId': '10002',
+        'started': '2021-01-17T12:34:00.000+0000',
+        'timeSpent': '3h 20m',
+        'timeSpentSeconds': 12000,
+        'updateAuthor': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': False,
+            'displayName': 'Mia Krystof',
+        },
+        'updated': '2021-01-18T23:45:00.000+0000',
+        'visibility': {
+            'identifier': '276f955c-63d7-42c8-9520-92d01dca0625',
+            'type': 'group',
+            'value': 'jira-developers',
+        },
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_get_issue_work_log(jira_api: JiraAPI):
     # GIVEN
     route = respx.get(get_url_pattern('issue/1/worklog'))

--- a/src/jiratui/api_controller/controller.py
+++ b/src/jiratui/api_controller/controller.py
@@ -2631,6 +2631,103 @@ class APIController:
             return APIControllerResponse(success=False, error=exception_details.get('message'))
         return APIControllerResponse()
 
+    async def update_worklog(
+        self,
+        issue_key_or_id: str,
+        worklog_id: str,
+        started: datetime,
+        time_spent: str,
+        time_remaining: str | None = None,
+        comment: str | None = None,
+        remaining_estimate: str | None = None,
+    ) -> APIControllerResponse:
+        """Updates a worklog associated to a work item.
+
+        Args:
+            issue_key_or_id: the id or key of the work item whose worklog we want to update.
+            worklog_id: the id of the worklog we want to update.
+            started: the datetime on which the worklog effort was started. Required when creating a worklog. Optional
+            when updating a worklog.
+            time_spent: the time spent working on the issue as days (#d), hours (#h), or minutes (#m or #). Required
+            when creating a worklog if timeSpentSeconds isn't provided. Optional when updating a worklog. Cannot be
+            provided if timeSpentSecond is provided.
+            time_remaining: the value to set as the issue's remaining time estimate, as days (#d), hours (#h), or
+            minutes (#m or #). For example, 2d. Required when adjustEstimate is new.
+            comment: a comment about the worklog in Atlassian Document Format. Optional when creating or updating a
+            worklog.
+            remaining_estimate: the current remaining estimate of the work item before the update takes place.
+
+        Returns:
+            An instance of APIControllerResponse with an instance of JiraWorklog as the result if the update
+            succeeds. Otherwise, an instance of APIControllerResponse with success=False.
+        """
+
+        remaining_time = None
+        if time_remaining and remaining_estimate and time_remaining != remaining_estimate:
+            remaining_time = time_remaining
+
+        try:
+            response: dict = await self.api.update_work_log(
+                issue_id_or_key=issue_key_or_id,
+                worklog_id=worklog_id,
+                time_spent=time_spent,
+                started=started,
+                time_remaining=remaining_time,
+                comment=comment,
+            )
+        except Exception as e:
+            exception_details: dict = self._extract_exception_details(e)
+            self.logger.error(
+                'Unable to update worklog',
+                extra={
+                    'time_spent': time_spent,
+                    'time_remaining': time_remaining,
+                    'current_remaining_estimate': remaining_estimate,
+                    'started': str(started) if started else None,
+                    **exception_details.get('extra', {}),
+                },
+            )
+            return APIControllerResponse(success=False, error=exception_details.get('message'))
+
+        update_author = None
+        if value := response.get('updateAuthor'):
+            update_author = JiraUser(
+                account_id=value.get('accountId')
+                if self.config.cloud
+                else value.get('emailAddress'),
+                display_name=value.get('displayName'),
+                active=value.get('active'),
+                username=value.get('name') if not self.config.cloud else None,
+                email=value.get('emailAddress'),
+            )
+        author = None
+        if value := response.get('author'):
+            author = JiraUser(
+                account_id=value.get('accountId')
+                if self.config.cloud
+                else value.get('emailAddress'),
+                display_name=value.get('displayName'),
+                active=value.get('active'),
+                username=value.get('name') if not self.config.cloud else None,
+                email=value.get('emailAddress'),
+            )
+
+        # the comment of a worklog could be a string if Jira DC API or Jira Cloud API v2 is used; if Jira Cloud API v3
+        # is used then this will be an ADF.
+        return APIControllerResponse(
+            result=JiraWorklog(
+                id=response.get('id'),
+                issue_id=response.get('issueId'),
+                started=isoparse(response.get('started')) if response.get('started') else None,
+                updated=isoparse(response.get('updated')) if response.get('updated') else None,
+                time_spent=response.get('timeSpent'),
+                time_spent_seconds=response.get('timeSpentSeconds'),
+                author=author,
+                update_author=update_author,
+                comment=response.get('comment'),
+            )
+        )
+
     async def get_fields(self, field_name: str | None = None) -> APIControllerResponse:
         """Retrieves system and custom issue fields.
 

--- a/src/jiratui/api_controller/tests/test_controller.py
+++ b/src/jiratui/api_controller/tests/test_controller.py
@@ -3876,6 +3876,150 @@ async def test_add_work_item_worklog_with_api_error(
 
 
 @pytest.mark.asyncio
+@patch.object(JiraAPI, 'update_work_log')
+async def test_update_work_item_worklog_entry(
+    update_work_log_mock: Mock, jira_api_controller: APIController
+):
+    # GIVEN
+    update_work_log_mock.return_value = {
+        'author': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': True,
+            'displayName': 'bart simpson',
+            'emailAddress': 'bart@simpson.com',
+            'key': 'bart',
+            'name': 'bart',
+        },
+        'created': '2021-01-17T12:34:00.000+0000',
+        'id': '2',
+        'issueId': '1',
+        'started': '2021-01-16T12:34:00.000+0000',
+        'timeSpent': '1h',
+        'timeSpentSeconds': 3600,
+        'updateAuthor': {
+            'accountId': '5b10a2844c20165700ede21g',
+            'active': True,
+            'displayName': 'bart simpson',
+            'emailAddress': 'bart@simpson.com',
+            'key': 'bart',
+            'name': 'bart',
+        },
+        'updated': '2021-01-17T12:34:00.000+0000',
+    }
+    # WHEN
+    response = await jira_api_controller.update_worklog(
+        '1',
+        '2',
+        datetime(2021, 1, 17, 12, 34, 0, tzinfo=timezone.utc),
+        '1h',
+        '2h',
+        'some comment',
+        '3h',
+    )
+    # THEN
+    assert isinstance(response, APIControllerResponse)
+    assert response.success is True
+    assert response.error is None
+    assert response.result == JiraWorklog(
+        id='2',
+        issue_id='1',
+        started=datetime(2021, 1, 16, 12, 34, 0, tzinfo=timezone.utc),
+        updated=datetime(2021, 1, 17, 12, 34, 0, tzinfo=timezone.utc),
+        time_spent='1h',
+        time_spent_seconds=3600,
+        author=JiraUser(
+            account_id='5b10a2844c20165700ede21g',
+            display_name='bart simpson',
+            active=True,
+            email='bart@simpson.com',
+            username=None,
+        ),
+        update_author=JiraUser(
+            account_id='5b10a2844c20165700ede21g',
+            display_name='bart simpson',
+            active=True,
+            email='bart@simpson.com',
+            username=None,
+        ),
+        comment=None,
+    )
+    update_work_log_mock.assert_called_once_with(
+        issue_id_or_key='1',
+        worklog_id='2',
+        started=datetime(2021, 1, 17, 12, 34, 0, tzinfo=timezone.utc),
+        time_spent='1h',
+        time_remaining='2h',
+        comment='some comment',
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(JiraAPI, 'update_work_log')
+async def test_update_work_item_worklog_entry_without_authors(
+    update_work_log_mock: Mock, jira_api_controller: APIController
+):
+    # GIVEN
+    update_work_log_mock.return_value = {
+        'author': None,
+        'created': '2021-01-17T12:34:00.000+0000',
+        'id': '2',
+        'issueId': '1',
+        'started': '2021-01-16T12:34:00.000+0000',
+        'timeSpent': '1h',
+        'timeSpentSeconds': 3600,
+        'updateAuthor': None,
+        'updated': '2021-01-17T12:34:00.000+0000',
+    }
+    # WHEN
+    response = await jira_api_controller.update_worklog(
+        '1',
+        '2',
+        datetime(2021, 1, 17, 12, 34, 0, tzinfo=timezone.utc),
+        '1h',
+        '2h',
+        'some comment',
+        '3h',
+    )
+    # THEN
+    assert isinstance(response, APIControllerResponse)
+    assert response.success is True
+    assert response.error is None
+    assert response.result == JiraWorklog(
+        id='2',
+        issue_id='1',
+        started=datetime(2021, 1, 16, 12, 34, 0, tzinfo=timezone.utc),
+        updated=datetime(2021, 1, 17, 12, 34, 0, tzinfo=timezone.utc),
+        time_spent='1h',
+        time_spent_seconds=3600,
+        author=None,
+        update_author=None,
+        comment=None,
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(JiraAPI, 'update_work_log')
+async def test_update_work_item_worklog_entry_with_api_error(
+    update_work_log_mock: Mock, jira_api_controller: APIController
+):
+    # GIVEN
+    update_work_log_mock.side_effect = ValueError('some error')
+    # WHEN
+    response = await jira_api_controller.update_worklog(
+        '1',
+        '2',
+        datetime(2021, 1, 17, 12, 34, 0, tzinfo=timezone.utc),
+        '1h',
+        '2h',
+        'some comment',
+        '3h',
+    )
+    # THEN
+    assert isinstance(response, APIControllerResponse)
+    assert response.success is False
+
+
+@pytest.mark.asyncio
 @patch.object(JiraAPI, 'add_issue_work_log')
 async def test_add_work_item_worklog_without_current_time_remaining(
     add_issue_work_log_mock: Mock,

--- a/src/jiratui/conftest.py
+++ b/src/jiratui/conftest.py
@@ -20,6 +20,7 @@ from jiratui.models import (
     JiraWorklog,
     LinkIssueType,
     Project,
+    TimeTracking,
     WorkItemsSearchOrderBy,
 )
 
@@ -406,6 +407,14 @@ def jira_issues() -> list[JiraIssue]:
                     ),
                 ),
             ],
+            time_tracking=TimeTracking(
+                time_spent='1m',
+                time_spent_seconds=60,
+                remaining_estimate='1h',
+                remaining_estimate_seconds=3600,
+                original_estimate_seconds=86400,
+                original_estimate='1d',
+            ),
         ),
     ]
 

--- a/src/jiratui/css/jt.tcss
+++ b/src/jiratui/css/jt.tcss
@@ -1442,3 +1442,7 @@ MultiSelectWidget {
 .message-tip {
     color: $text-muted;
 }
+
+.time-tracking-container {
+    height: auto;
+}

--- a/src/jiratui/models.py
+++ b/src/jiratui/models.py
@@ -826,9 +826,11 @@ class JiraWorklog(BaseModel):
                 return f'{self.author.display_user} logged {self.time_spent}'
         else:
             if local_dt:
-                return f'{self.author.display_user} logged {self.time_spent} on {datetime.strftime(local_dt, "%Y-%m-%d %H:%M")}'
+                return (
+                    f'Logged {self.time_spent} on {datetime.strftime(local_dt, "%Y-%m-%d %H:%M")}'
+                )
             else:
-                return f'{self.author.display_user} logged {self.time_spent}'
+                return f'Logged {self.time_spent}'
 
     def get_comment(self) -> str:
         """Gets the value of the worklog's comment.
@@ -853,7 +855,7 @@ class JiraWorklog(BaseModel):
     def display_time_spent(self):
         return self.time_spent if self.time_spent else ''
 
-    def display_started(self):
+    def display_started(self) -> str:
         if self.started:
             local_dt = self.started.astimezone()
             return datetime.strftime(local_dt, '%Y-%m-%d %H:%M')
@@ -867,6 +869,12 @@ class JiraWorklog(BaseModel):
     def display_update_author(self) -> str:
         if self.update_author:
             return self.update_author.display_user
+        return ''
+
+    def get_date_started(self) -> str:
+        if self.started:
+            local_dt = self.started.astimezone()
+            return datetime.strftime(local_dt, '%Y-%m-%d %H:%M')
         return ''
 
 

--- a/src/jiratui/utils/tests/test_adf_to_md_conversion.py
+++ b/src/jiratui/utils/tests/test_adf_to_md_conversion.py
@@ -139,7 +139,29 @@ Hello world
     # WHEN
     adf = convert_markdown_to_adf(markdown)
     # THEN
-    assert adf == {'type': 'doc', 'version': 1, 'content': []}
+    assert adf == {
+        'type': 'doc',
+        'version': 1,
+        'content': [
+            {
+                'type': 'expand',
+                'content': [
+                    {
+                        'type': 'paragraph',
+                        'content': [
+                            {
+                                'type': 'text',
+                                'text': 'Hello world',
+                            },
+                        ],
+                    },
+                ],
+                'attrs': {
+                    'title': 'Hello world',
+                },
+            },
+        ],
+    }
 
 
 def test_adf_nested_expand():

--- a/src/jiratui/widgets/work_item_details/details.py
+++ b/src/jiratui/widgets/work_item_details/details.py
@@ -25,7 +25,7 @@ Key Features:
     - Keyboard shortcuts for quick access (Ctrl+S to save, Ctrl+L for worklog, etc.)
     - Asynchronous API communication with Jira for updating work items
     - Support for work item flagging with optional notes
-    - Work log viewing and creation workflows
+    - Work log viewing
     - Time tracking display and management
     - Priority, status, and parent issue transitions
 
@@ -54,7 +54,7 @@ Dependencies:
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, cast
 
 from textual.app import ComposeResult
@@ -105,7 +105,6 @@ from jiratui.widgets.work_item_details.fields import (
 )
 from jiratui.widgets.work_item_details.flag_work_item import FlagWorkItemScreen
 from jiratui.widgets.work_item_details.work_log import (
-    LogWorkScreen,
     WorkItemWorkLogScreen,
 )
 
@@ -177,22 +176,14 @@ class IssueDetailsWidget(Vertical):
             show=False,
         ),
         Binding(
-            key='ctrl+l',
+            key='ctrl+l, ctrl+t',
             action='view_worklog',
             description='Worklog',
             show=True,
+            key_display='^l',
         ),
         Binding(
-            key='ctrl+t',
-            action='log_work',
-            description='Log Work',
-            show=True,
-        ),
-        Binding(
-            key='ctrl+f',
-            action='flag_work_item',
-            description='Flag',
-            show=True,
+            key='ctrl+f', action='flag_work_item', description='Flag', show=True, key_display='^f'
         ),
     ]
 
@@ -281,10 +272,6 @@ class IssueDetailsWidget(Vertical):
     @property
     def issue_due_date_field(self) -> WorkItemDetailsDueDate:
         return self.query_one(WorkItemDetailsDueDate)
-
-    @property
-    def time_tracking_widget(self) -> TimeTrackingWidget:
-        return self.query_one(TimeTrackingWidget)
 
     @property
     def issue_resolution_date_field(self) -> ReadOnlyTextField:
@@ -483,32 +470,9 @@ class IssueDetailsWidget(Vertical):
         Returns:
             `None`.
         """
+
         if self.issue:
-            self.app.push_screen(
-                WorkItemWorkLogScreen(self.issue.key), self._handle_worklog_screen_dismissal
-            )
-
-    def action_log_work(self) -> None:
-        """Opens a pop-up modal to allow the user to log work for the current work item.
-
-        Returns:
-            None
-        """
-        if self.issue:
-            current_remaining_estimate = None
-            if self.issue.time_tracking:
-                current_remaining_estimate = self.issue.time_tracking.remaining_estimate
-            self.app.push_screen(
-                LogWorkScreen(self.issue.key, current_remaining_estimate),
-                self._request_adding_worklog,
-            )
-
-    def _handle_worklog_screen_dismissal(self, response: dict | None = None) -> None:
-        # when the screen that shows work logs for a work item is dismissed, check the result and if
-        # required fetch the details of the work item to refresh the details form and reflect the changes in time
-        # tracking information
-        if response.get('work_logs_deleted'):
-            self.run_worker(self._refresh_work_item_details)
+            self.app.push_screen(WorkItemWorkLogScreen(self.issue.key, self.issue.time_tracking))
 
     async def _refresh_work_item_details(self) -> None:
         """Fetches the details of the work item to retrieve the latest changes and update the details form.
@@ -520,88 +484,6 @@ class IssueDetailsWidget(Vertical):
         issue_details_response = await application.api.get_issue(issue_id_or_key=self.issue.key)
         if issue_details_response.success and issue_details_response.result:
             self.issue = issue_details_response.result.issues[0]
-
-    def _request_adding_worklog(self, data: dict) -> None:
-        """Requests a worker to attempt to log work for the currently-selected item.
-
-        Args:
-            data: the data returned by the modal screen after the user clicks the "save" button.
-
-        Returns:
-            None
-        """
-
-        if data:
-            self.run_worker(
-                self._add_worklog(
-                    work_item_key=data.get('key'),
-                    time_spent=data.get('time_spent'),
-                    time_remaining=data.get('time_remaining'),
-                    description=data.get('description'),
-                    started=data.get('started'),
-                    current_remaining_estimate=data.get('current_remaining_estimate'),
-                )
-            )
-
-    async def _add_worklog(
-        self,
-        work_item_key: str,
-        time_spent: str,
-        started: str,
-        time_remaining: str | None = None,
-        description: str | None = None,
-        current_remaining_estimate: str | None = None,
-    ) -> None:
-        """Logs work for a work item.
-
-        Args:
-            work_item_key: the key of the work item whose work log we are updating.
-            time_spent: the time spent on the task. E.g. 1w 1d
-            time_remaining: the time remaining in the task. E.g. 1w 1d
-            description: an optional description of the work done in the task.
-            started: the date/time on which the work was started.
-            current_remaining_estimate: the current remaining estimate of the task.
-
-        Return:
-            None
-        """
-
-        if not work_item_key:
-            self.notify('Select a work item before logging work.', title='Worklog')
-        if not time_spent:
-            # this should not happen but if for some reason it does then make sure to let the user know that we can't
-            # add the worklog
-            self.notify(
-                'You need to provide the time spent on the task to log work', title='Worklog'
-            )
-        else:
-            application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
-            started_datetime: datetime | None = None
-            if started:
-                naive_dt = datetime.fromisoformat(started)
-                # assume the date/time value is in local time and convert to UTC
-                started_datetime = naive_dt.replace(
-                    tzinfo=None
-                ).astimezone()  # make it aware of local TZ as defined by the OS
-                started_datetime = started_datetime.astimezone(timezone.utc)
-            response: APIControllerResponse = await application.api.add_work_item_worklog(
-                issue_key_or_id=work_item_key,
-                started=started_datetime,
-                time_spent=time_spent,
-                time_remaining=time_remaining,
-                comment=description,
-                current_remaining_estimate=current_remaining_estimate,
-            )
-            if response.success:
-                self.notify('Work logged successfully', title='Worklog')
-                # refresh the details of the work item to reflect the changes in time tracking information
-                await self._refresh_work_item_details()
-            else:
-                self.notify(
-                    f'Failed to log work for the item: {response.error}',
-                    severity='error',
-                    title='Worklog',
-                )
 
     def _update_priority_selection(
         self, priorities: list[tuple[str, str]], priority_id: str

--- a/src/jiratui/widgets/work_item_details/tests/test_issue_details_widget.py
+++ b/src/jiratui/widgets/work_item_details/tests/test_issue_details_widget.py
@@ -39,7 +39,7 @@ from jiratui.widgets.work_item_details.fields import (
     WorkItemDetailsDueDate,
 )
 from jiratui.widgets.work_item_details.flag_work_item import FlagWorkItemScreen
-from jiratui.widgets.work_item_details.work_log import LogWorkScreen, WorkItemWorkLogScreen
+from jiratui.widgets.work_item_details.work_log import WorkItemWorkLogScreen
 
 
 @pytest.fixture
@@ -197,6 +197,7 @@ def jira_issue() -> JiraIssue:
                 ),
             ),
         ],
+        time_tracking=TimeTracking(time_spent='10'),
     )
 
 
@@ -1573,17 +1574,46 @@ async def test_action_flag_work_item_does_not_open_modal_screen(
         assert not isinstance(app.screen, FlagWorkItemScreen)
 
 
-@patch.object(IssueDetailsWidget, 'issue')
+@patch.object(APIController, 'search_users_assignable_to_issue')
+@patch.object(APIController, 'get_issue')
+@patch('jiratui.widgets.screen.MainScreen._search_work_items')
+@patch('jiratui.widgets.screen.MainScreen.fetch_statuses')
+@patch('jiratui.widgets.screen.MainScreen.fetch_issue_types')
+@patch('jiratui.widgets.screen.MainScreen.fetch_projects')
 @pytest.mark.asyncio
-async def test_action_view_worklog(issue_mock: Mock, app: JiraApp):
-    # GIVEN
+async def test_action_view_worklog_opens_modal_screen(
+    search_projects_mock: AsyncMock,
+    fetch_issue_types_mock: AsyncMock,
+    fetch_statuses_mock: AsyncMock,
+    search_work_items_mock: AsyncMock,
+    get_issue_mock: AsyncMock,
+    search_users_assignable_to_issue_mock: AsyncMock,
+    jira_issues: list[JiraIssue],
+    app,
+):
+    app.config.search_results_truncate_work_item_summary = 10
+    app.config.search_results_style_work_item_status = False
+    app.config.search_results_style_work_item_type = False
+    app.config.search_results_per_page = 10
+    app.config.show_issue_web_links = False
     async with app.run_test() as pilot:
-        details_widget = IssueDetailsWidget()
-        await app.mount(details_widget)
-        await pilot.pause()
+        # GIVEN
+        search_work_items_mock.return_value = WorkItemSearchResult(
+            total=2,
+            response=JiraIssueSearchResponse(
+                issues=jira_issues, next_page_token=None, is_last=None
+            ),
+        )
+        get_issue_mock.return_value = APIControllerResponse(
+            result=JiraIssueSearchResponse(issues=[jira_issues[1]])
+        )
         # WHEN
-        details_widget.action_view_worklog()
-        # THEN
+        await pilot.press('ctrl+r')
+        await pilot.press('down')
+        await pilot.press('enter')
+        await pilot.press('3')
+        await pilot.press('tab')
+        await pilot.press('ctrl+l')
         assert isinstance(app.screen, WorkItemWorkLogScreen)
 
 
@@ -1594,54 +1624,8 @@ async def test_action_view_worklog_no_issue_set(app: JiraApp):
         details_widget = IssueDetailsWidget()
         await app.mount(details_widget)
         await pilot.pause()
+        assert details_widget.issue is None
         # WHEN
         details_widget.action_view_worklog()
         # THEN
         assert not isinstance(app.screen, WorkItemWorkLogScreen)
-
-
-@patch.object(IssueDetailsWidget, 'issue')
-@pytest.mark.asyncio
-async def test_action_log_work(issue_mock: Mock, app: JiraApp):
-    # GIVEN
-    async with app.run_test() as pilot:
-        details_widget = IssueDetailsWidget()
-        await app.mount(details_widget)
-        await pilot.pause()
-        issue_mock.configure_mock(key='key-2', time_tracking=None)
-        # WHEN
-        details_widget.action_log_work()
-        # THEN
-        assert isinstance(app.screen, LogWorkScreen)
-        assert app.screen._work_item_key == 'key-2'
-        assert app.screen._current_remaining_estimate is None
-
-
-@patch.object(IssueDetailsWidget, 'issue')
-@pytest.mark.asyncio
-async def test_action_log_work_with_time_remaining(issue_mock: Mock, app: JiraApp):
-    # GIVEN
-    async with app.run_test() as pilot:
-        details_widget = IssueDetailsWidget()
-        await app.mount(details_widget)
-        await pilot.pause()
-        issue_mock.configure_mock(key='key-2', time_tracking=TimeTracking(remaining_estimate='1h'))
-        # WHEN
-        details_widget.action_log_work()
-        # THEN
-        assert isinstance(app.screen, LogWorkScreen)
-        assert app.screen._work_item_key == 'key-2'
-        assert app.screen._current_remaining_estimate == '1h'
-
-
-@pytest.mark.asyncio
-async def test_action_log_work_no_issue_set(app: JiraApp):
-    # GIVEN
-    async with app.run_test() as pilot:
-        details_widget = IssueDetailsWidget()
-        await app.mount(details_widget)
-        await pilot.pause()
-        # WHEN
-        details_widget.action_log_work()
-        # THEN
-        assert not isinstance(app.screen, LogWorkScreen)

--- a/src/jiratui/widgets/work_item_details/tests/test_worklog_screen.py
+++ b/src/jiratui/widgets/work_item_details/tests/test_worklog_screen.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timezone
 from typing import cast
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest
+from textual.containers import Horizontal
 from textual.widgets import Button
 
-from jiratui.api_controller.controller import APIControllerResponse
+from jiratui.api_controller.controller import APIController, APIControllerResponse
 from jiratui.app import JiraApp
 from jiratui.models import JiraIssue, JiraIssueSearchResponse, JiraWorklog, PaginatedJiraWorklog
 from jiratui.widgets.filters import ProjectSelectionInput
@@ -14,11 +15,22 @@ from jiratui.widgets.work_item_details.details import IssueDetailsWidget
 from jiratui.widgets.work_item_details.work_log import (
     LogDateTimeInput,
     LogWorkScreen,
+    LogWorkScreenMode,
+    LogWorkScreenResult,
     TimeRemainingInput,
     TimeSpentInput,
     WorkDescription,
     WorkItemWorkLogScreen,
+    WorkLogCollapsible,
 )
+
+
+@pytest.fixture()
+def mock_configuration():
+    with patch('jiratui.utils.urls.CONFIGURATION') as mock_config_var:
+        mock_config = MagicMock()
+        mock_config_var.get.return_value = mock_config
+        yield mock_config
 
 
 @pytest.mark.parametrize(
@@ -73,17 +85,48 @@ async def test_log_work_screen(
 async def test_log_work_screen_initial_state(
     current_remaining_estimate: str,
     jira_api_controller,
+    jira_issues: list[JiraIssue],
     app,
 ):
     async with app.run_test():
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1',
+                LogWorkScreenMode.CREATE,
+                current_remaining_estimate=jira_issues[1].time_tracking.remaining_estimate,
+                current_time_spent=jira_issues[1].time_tracking.time_spent,
+                current_date_started='2026-01-01',
+                current_description='some text',
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
+        assert screen.save_button.disabled is False
+        assert screen.log_date_time_input.disabled is False
+        assert screen.work_description_input.disabled is False
+        assert screen.time_spent_input.value == jira_issues[1].time_tracking.time_spent
+        assert screen.time_remaining_input.value == jira_issues[1].time_tracking.remaining_estimate
+        assert screen.work_description_input.text == 'some text'
+        assert screen.log_date_time_input.value == '2026-01-01'
+
+
+@pytest.mark.parametrize('current_remaining_estimate', ['', '2h'])
+@pytest.mark.asyncio
+async def test_log_work_screen_initial_state_without_initial_data(
+    current_remaining_estimate: str,
+    jira_api_controller,
+    jira_issues: list[JiraIssue],
+    app,
+):
+    async with app.run_test():
+        await app.push_screen(LogWorkScreen('1', LogWorkScreenMode.CREATE))
+        screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
         assert screen.save_button.disabled is True
         assert screen.log_date_time_input.disabled is True
         assert screen.work_description_input.disabled is True
         assert screen.time_spent_input.value == ''
-        assert screen.time_remaining_input.value == current_remaining_estimate
+        assert screen.time_remaining_input.value == ''
+        assert screen.work_description_input.text == ''
+        assert screen.log_date_time_input.value == datetime.today().strftime('%Y-%m-%d %H:%M')
 
 
 @pytest.mark.parametrize('current_remaining_estimate', ['', '2h'])
@@ -94,9 +137,12 @@ async def test_log_work_screen_with_valid_time_spent_value(
     app,
 ):
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -118,9 +164,12 @@ async def test_log_work_screen_with_incorrect_time_spent_value(
     app,
 ):
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -141,9 +190,12 @@ async def test_log_work_screen_with_correct_datetime_value(
 ):
     # GIVEN
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -193,9 +245,12 @@ async def test_log_work_screen_with_incorrect_datetime_value(
     app,
 ):
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -238,9 +293,12 @@ async def test_log_work_screen_with_empty_datetime_value(
 ):
     # GIVEN
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -282,9 +340,12 @@ async def test_log_work_screen_with_valid_time_spent_incorrect_time_remaining(
     app,
 ):
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -312,9 +373,12 @@ async def test_log_work_screen_with_valid_time_spent_correct_time_remaining(
     app,
 ):
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -357,9 +421,12 @@ async def test_log_work_screen_saving(
     app,
 ):
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -394,14 +461,15 @@ async def test_log_work_screen_saving(
         assert isinstance(screen.focused, Button)
         await pilot.press('enter')
         dismiss_mock.assert_called_once_with(
-            {
-                'key': '1',
-                'time_spent': '1h',
-                'time_remaining': current_remaining_estimate,
-                'description': 't',
-                'started': '2025-10-18T13:45',
-                'current_remaining_estimate': current_remaining_estimate,
-            }
+            LogWorkScreenResult(
+                work_item_key='1',
+                mode=LogWorkScreenMode.CREATE,
+                worklog_id=None,
+                time_spent='1h',
+                time_remaining=current_remaining_estimate,
+                description='t',
+                started='2025-10-18T13:45',
+            )
         )
 
 
@@ -417,9 +485,12 @@ async def test_adding_worklog_user_clicks_cancel(
     app,
 ):
     async with app.run_test() as pilot:
-        await app.push_screen(LogWorkScreen('1', current_remaining_estimate))
+        await app.push_screen(
+            LogWorkScreen(
+                '1', LogWorkScreenMode.CREATE, current_remaining_estimate=current_remaining_estimate
+            )
+        )
         screen = cast('LogWorkScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        screen._current_remaining_estimate = current_remaining_estimate
         assert screen.time_spent_input.has_focus is True
         assert isinstance(screen.focused, TimeSpentInput)
         await pilot.press('1')
@@ -454,11 +525,11 @@ async def test_adding_worklog_user_clicks_cancel(
         await pilot.press('tab')
         assert isinstance(screen.focused, Button)
         await pilot.press('enter')
-        dismiss_mock.assert_called_once_with({})
+        dismiss_mock.assert_called_once_with(None)
         refresh_work_item_details_mock.assert_not_called()
 
 
-@patch.object(IssueDetailsWidget, '_refresh_work_item_details')
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
 @patch('jiratui.widgets.screen.APIController.add_work_item_worklog')
 @patch('jiratui.widgets.screen.APIController.get_issue')
 @patch('jiratui.widgets.screen.MainScreen._search_work_items')
@@ -473,7 +544,7 @@ async def test_adding_worklog_with_success(
     search_work_items_mock: AsyncMock,
     get_issue_mock: AsyncMock,
     add_work_item_worklog_mock: AsyncMock,
-    refresh_work_item_details_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
     jira_issues: list[JiraIssue],
     app,
 ):
@@ -498,10 +569,14 @@ async def test_adding_worklog_with_success(
         # WHEN/THEN
         await pilot.press('ctrl+r')
         await pilot.press('down')
+        await pilot.press('down')
         await pilot.press('enter')
         await pilot.press('3')
         await pilot.press('tab')
-        await pilot.press('ctrl+t')
+        await pilot.press('ctrl+l')
+        assert isinstance(app.screen, WorkItemWorkLogScreen)
+        await pilot.press('tab')
+        await pilot.press('n')
         assert isinstance(app.screen, LogWorkScreen)
         date_time_value = app.screen.log_date_time_input.value  # type:ignore
         await pilot.press('1')
@@ -515,7 +590,7 @@ async def test_adding_worklog_with_success(
         await pilot.press('tab')  # move to save button
         await pilot.press('enter')
         # THEN
-        assert isinstance(app.screen, MainScreen)
+        assert isinstance(app.screen, WorkItemWorkLogScreen)
         naive_dt = datetime.fromisoformat(date_time_value)
         # assume the date/time value is in local time and convert to UTC
         started_datetime = naive_dt.replace(
@@ -528,12 +603,12 @@ async def test_adding_worklog_with_success(
             time_spent='1w',
             time_remaining='2w',
             comment='-',
-            current_remaining_estimate=None,
+            current_remaining_estimate=jira_issues[1].time_tracking.remaining_estimate,
         )
-        refresh_work_item_details_mock.assert_called_once()
+        fetch_work_logs_mock.assert_has_calls([call(), call(fetch_time_tracking=True)])
 
 
-@patch.object(IssueDetailsWidget, '_refresh_work_item_details')
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
 @patch('jiratui.widgets.screen.APIController.add_work_item_worklog')
 @patch('jiratui.widgets.screen.APIController.get_issue')
 @patch('jiratui.widgets.screen.MainScreen._search_work_items')
@@ -548,7 +623,7 @@ async def test_adding_worklog_with_error_adding_new_worklog(
     search_work_items_mock: AsyncMock,
     get_issue_mock: AsyncMock,
     add_work_item_worklog_mock: AsyncMock,
-    refresh_work_item_details_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
     jira_issues: list[JiraIssue],
     app,
 ):
@@ -576,7 +651,10 @@ async def test_adding_worklog_with_error_adding_new_worklog(
         await pilot.press('enter')
         await pilot.press('3')
         await pilot.press('tab')
-        await pilot.press('ctrl+t')
+        await pilot.press('ctrl+l')
+        assert isinstance(app.screen, WorkItemWorkLogScreen)
+        await pilot.press('tab')
+        await pilot.press('n')
         assert isinstance(app.screen, LogWorkScreen)
         date_time_value = app.screen.log_date_time_input.value  # type:ignore
         await pilot.press('1')
@@ -590,7 +668,7 @@ async def test_adding_worklog_with_error_adding_new_worklog(
         await pilot.press('tab')  # move to save button
         await pilot.press('enter')
         # THEN
-        assert isinstance(app.screen, MainScreen)
+        assert isinstance(app.screen, WorkItemWorkLogScreen)
         naive_dt = datetime.fromisoformat(date_time_value)
         # assume the date/time value is in local time and convert to UTC
         started_datetime = naive_dt.replace(
@@ -603,9 +681,9 @@ async def test_adding_worklog_with_error_adding_new_worklog(
             time_spent='1w',
             time_remaining='2w',
             comment='-',
-            current_remaining_estimate=None,
+            current_remaining_estimate=jira_issues[1].time_tracking.remaining_estimate,
         )
-        refresh_work_item_details_mock.assert_not_called()
+        fetch_work_logs_mock.assert_has_calls([call()])
 
 
 @patch('jiratui.widgets.screen.APIController.add_work_item_worklog')
@@ -649,7 +727,10 @@ async def test_adding_worklog_when_users_clicks_cancel(
         await pilot.press('enter')
         await pilot.press('3')
         await pilot.press('tab')
-        await pilot.press('ctrl+t')
+        await pilot.press('ctrl+l')
+        assert isinstance(app.screen, WorkItemWorkLogScreen)
+        await pilot.press('tab')
+        await pilot.press('n')
         assert isinstance(app.screen, LogWorkScreen)
         await pilot.press('1')
         await pilot.press('w')
@@ -663,7 +744,7 @@ async def test_adding_worklog_when_users_clicks_cancel(
         await pilot.press('tab')  # move to cancel button
         await pilot.press('enter')
         # THEN
-        assert isinstance(app.screen, MainScreen)
+        assert isinstance(app.screen, WorkItemWorkLogScreen)
         add_work_item_worklog_mock.assert_not_called()
 
 
@@ -723,10 +804,10 @@ async def test_open_modal_to_view_work_logs(
         assert screen.root_container.border_title == 'Worklog - key-2'
 
 
-@patch('jiratui.widgets.screen.APIController.remove_worklog')
+@patch.object(WorkItemWorkLogScreen, '_delete_log_entry')
 @patch('jiratui.widgets.work_item_details.work_log.build_external_url_for_work_log')
-@patch('jiratui.widgets.screen.APIController.get_work_item_worklog')
-@patch('jiratui.widgets.screen.APIController.get_issue')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
 @patch('jiratui.widgets.screen.MainScreen._search_work_items')
 @patch('jiratui.widgets.screen.MainScreen.fetch_statuses')
 @patch('jiratui.widgets.screen.MainScreen.fetch_issue_types')
@@ -740,7 +821,7 @@ async def test_delete_worklog(
     get_issue_mock: AsyncMock,
     get_work_item_worklog_mock: AsyncMock,
     build_external_url_for_work_log_mock: Mock,
-    remove_worklog_mock: Mock,
+    delete_log_entry_mock: Mock,
     jira_issues: list[JiraIssue],
     jira_worklogs: list[JiraWorklog],
     app,
@@ -758,7 +839,6 @@ async def test_delete_worklog(
         result=PaginatedJiraWorklog(logs=jira_worklogs, max_results=10, start_at=0, total=2)
     )
     build_external_url_for_work_log_mock.return_value = 'foo.bar'
-    remove_worklog_mock.return_value = APIControllerResponse()
     async with app.run_test() as pilot:
         search_work_items_mock.return_value = WorkItemSearchResult(
             total=2,
@@ -775,20 +855,18 @@ async def test_delete_worklog(
         await pilot.press('tab')
         await pilot.press('ctrl+l')
         screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        assert screen.root_container.border_subtitle == 'Showing 2 of 2'
         assert screen.root_container.border_title == 'Worklog - key-2'
         assert screen._work_logs_deleted is False
         await pilot.press('tab')
         await pilot.press('d')
         # THEN
         assert isinstance(app.screen, WorkItemWorkLogScreen)
-        get_work_item_worklog_mock.assert_called_once_with('key-2')
-        remove_worklog_mock.assert_called_once_with('key-2', '1')
-        assert screen.root_container.border_subtitle == 'Showing 1 of 1'
-        assert screen._work_logs_deleted is True
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        delete_log_entry_mock.assert_called_once()
 
 
-@patch.object(IssueDetailsWidget, '_handle_worklog_screen_dismissal')
+@patch.object(WorkItemWorkLogScreen, '_delete_log_entry')
 @patch('jiratui.widgets.screen.APIController.remove_worklog')
 @patch('jiratui.widgets.work_item_details.work_log.build_external_url_for_work_log')
 @patch('jiratui.widgets.screen.APIController.get_work_item_worklog')
@@ -807,7 +885,7 @@ async def test_delete_worklog_and_close_worklog_screen(
     get_work_item_worklog_mock: AsyncMock,
     build_external_url_for_work_log_mock: Mock,
     remove_worklog_mock: Mock,
-    handle_worklog_screen_dismissal_mock: Mock,
+    delete_log_entry_mock: Mock,
     jira_issues: list[JiraIssue],
     jira_worklogs: list[JiraWorklog],
     app,
@@ -842,7 +920,6 @@ async def test_delete_worklog_and_close_worklog_screen(
         await pilot.press('tab')
         await pilot.press('ctrl+l')
         screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
-        assert screen.root_container.border_subtitle == 'Showing 2 of 2'
         assert screen.root_container.border_title == 'Worklog - key-2'
         assert screen._work_logs_deleted is False
         await pilot.press('tab')
@@ -850,10 +927,9 @@ async def test_delete_worklog_and_close_worklog_screen(
         await pilot.press('escape')
         # THEN
         assert isinstance(app.screen, MainScreen)
-        handle_worklog_screen_dismissal_mock.assert_called_once_with({'work_logs_deleted': True})
+        delete_log_entry_mock.assert_called_once()
 
 
-@patch.object(IssueDetailsWidget, '_handle_worklog_screen_dismissal')
 @patch('jiratui.widgets.screen.APIController.remove_worklog')
 @patch('jiratui.widgets.work_item_details.work_log.build_external_url_for_work_log')
 @patch('jiratui.widgets.screen.APIController.get_work_item_worklog')
@@ -872,7 +948,6 @@ async def test_show_and_close_worklog_screen_without_deleting(
     get_work_item_worklog_mock: AsyncMock,
     build_external_url_for_work_log_mock: Mock,
     remove_worklog_mock: Mock,
-    handle_worklog_screen_dismissal_mock: Mock,
     jira_issues: list[JiraIssue],
     jira_worklogs: list[JiraWorklog],
     app,
@@ -911,7 +986,6 @@ async def test_show_and_close_worklog_screen_without_deleting(
         await pilot.press('escape')
         # THEN
         assert isinstance(app.screen, MainScreen)
-        handle_worklog_screen_dismissal_mock.assert_called_once_with({'work_logs_deleted': False})
 
 
 @patch.object(JiraApp, 'open_url')
@@ -970,3 +1044,670 @@ async def test_open_worklog_in_browser(
         assert isinstance(app.screen, WorkItemWorkLogScreen)
         get_work_item_worklog_mock.assert_called_once_with('key-2')
         open_url_mock.assert_called_once_with('foo.bar')
+
+
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_fetch_work_logs_without_initial_time_tracking_set(
+    get_issue_mock: AsyncMock, get_work_item_worklog_mock: AsyncMock, jira_issues, app
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, None))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # THEN
+        get_issue_mock.assert_called_once_with(issue_id_or_key=work_item.key)
+        assert screen._work_item_time_tracking == work_item.time_tracking
+        assert screen.query_one('#time-tracking-container', Horizontal) is not None
+        get_work_item_worklog_mock.assert_called_once_with('key-2')
+
+
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_fetch_work_logs_without_initial_time_tracking_set_fail_to_get_issue(
+    get_issue_mock: AsyncMock, get_work_item_worklog_mock: AsyncMock, jira_issues, app
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(success=False)
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, None))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # THEN
+        get_issue_mock.assert_called_once_with(issue_id_or_key=work_item.key)
+        assert screen._work_item_time_tracking is None
+        assert screen.query_one('#time-tracking-container', Horizontal) is not None
+        get_work_item_worklog_mock.assert_called_once_with('key-2')
+
+
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_fetch_work_logs_with_initial_time_tracking_set(
+    get_issue_mock: AsyncMock, get_work_item_worklog_mock: AsyncMock, jira_issues, app
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # THEN
+        get_issue_mock.assert_not_called()
+        assert screen._work_item_time_tracking == work_item.time_tracking
+        assert screen.query_one('#time-tracking-container', Horizontal) is not None
+        get_work_item_worklog_mock.assert_called_once_with('key-2')
+
+
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_fetch_work_logs_work_item_has_worklogs(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    jira_issues,
+    mock_configuration,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(
+            logs=[
+                JiraWorklog(id='1', issue_id=work_item.id, author=work_item.reporter),
+            ],
+            max_results=1,
+            start_at=0,
+            total=1,
+        )
+    )
+    mock_configuration.jira_base_url = 'http://foo.bar'
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # THEN
+        get_issue_mock.assert_not_called()
+        assert screen._work_item_time_tracking == work_item.time_tracking
+        assert screen.query_one('#time-tracking-container', Horizontal) is not None
+        get_work_item_worklog_mock.assert_called_once_with('key-2')
+        assert len(screen.work_log_items_container.children) == 1
+
+
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_fetch_work_logs_with_fetch_time_tracking_true(
+    get_issue_mock: AsyncMock, get_work_item_worklog_mock: AsyncMock, jira_issues, app
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, None))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await screen._fetch_work_logs(fetch_time_tracking=True)
+        # THEN
+        get_issue_mock.assert_has_calls(
+            [call(issue_id_or_key=work_item.key), call(issue_id_or_key=work_item.key)]
+        )
+        assert screen._work_item_time_tracking == work_item.time_tracking
+
+
+@patch.object(WorkItemWorkLogScreen, '_add_worklog_entry')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_log_work_in_create_mode(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    add_worklog_entry_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    screen_result = LogWorkScreenResult(
+        mode=LogWorkScreenMode.CREATE,
+        work_item_key=work_item.key,
+        time_spent='1h',
+        started='2026-01-01 12:30',
+    )
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await screen._log_work(screen_result)
+        # THEN
+        get_issue_mock.assert_not_called()
+        add_worklog_entry_mock.assert_called_once_with(
+            work_item_key=work_item.key, data=screen_result
+        )
+
+
+@patch.object(WorkItemWorkLogScreen, '_update_worklog_entry')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_log_work_in_update_mode(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    update_worklog_entry_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    screen_result = LogWorkScreenResult(
+        mode=LogWorkScreenMode.UPDATE,
+        work_item_key=work_item.key,
+        worklog_id='1',
+        time_spent='1h',
+        started='2026-01-01 12:30',
+    )
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await screen._log_work(screen_result)
+        # THEN
+        get_issue_mock.assert_not_called()
+        update_worklog_entry_mock.assert_called_once_with(worklog_id='1', data=screen_result)
+
+
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
+@patch.object(APIController, 'add_work_item_worklog')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_add_worklog_entry_without_work_item_key(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    add_work_item_worklog_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    screen_result = LogWorkScreenResult(
+        mode=LogWorkScreenMode.CREATE,
+        work_item_key=work_item.key,
+        time_spent='1h',
+        started='2026-01-01 12:30',
+    )
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        result = await screen._add_worklog_entry('', screen_result)  # type:ignore[func-returns-value]
+        # THEN
+        get_issue_mock.assert_not_called()
+        add_work_item_worklog_mock.assert_not_called()
+        fetch_work_logs_mock.assert_has_calls([call()])
+        assert result is None
+
+
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
+@patch.object(APIController, 'add_work_item_worklog')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_add_worklog_entry_without_time_spent(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    add_work_item_worklog_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    screen_result = LogWorkScreenResult(
+        mode=LogWorkScreenMode.CREATE,
+        work_item_key=work_item.key,
+        time_spent='',
+        started='2026-01-01 12:30',
+    )
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        result = await screen._add_worklog_entry(work_item.key, screen_result)  # type:ignore[func-returns-value]
+        # THEN
+        get_issue_mock.assert_not_called()
+        add_work_item_worklog_mock.assert_not_called()
+        fetch_work_logs_mock.assert_has_calls([call()])
+        assert result is None
+
+
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
+@patch.object(APIController, 'add_work_item_worklog')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_add_worklog_entry(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    add_work_item_worklog_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    screen_result = LogWorkScreenResult(
+        mode=LogWorkScreenMode.CREATE,
+        work_item_key=work_item.key,
+        time_spent='1h',
+        started='2026-01-01 12:30',
+    )
+    add_work_item_worklog_mock.return_value = APIControllerResponse()
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        result = await screen._add_worklog_entry(work_item.key, screen_result)  # type:ignore[func-returns-value]
+        # THEN
+        get_issue_mock.assert_not_called()
+        add_work_item_worklog_mock.assert_called_once_with(
+            issue_key_or_id=work_item.key,
+            started=datetime.fromisoformat(screen_result.started).astimezone(timezone.utc),
+            time_spent=screen_result.time_spent,
+            time_remaining=screen_result.time_remaining,
+            comment=screen_result.description,
+            current_remaining_estimate=screen._work_item_time_tracking.remaining_estimate,
+        )
+        fetch_work_logs_mock.assert_has_calls([call(), call(fetch_time_tracking=True)])
+        assert result is None
+
+
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
+@patch.object(APIController, 'add_work_item_worklog')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_add_worklog_entry_fails_to_add_entry(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    add_work_item_worklog_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    screen_result = LogWorkScreenResult(
+        mode=LogWorkScreenMode.CREATE,
+        work_item_key=work_item.key,
+        time_spent='1h',
+        started='2026-01-01 12:30',
+    )
+    add_work_item_worklog_mock.return_value = APIControllerResponse(success=False)
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        result = await screen._add_worklog_entry(work_item.key, screen_result)  # type:ignore[func-returns-value]
+        # THEN
+        get_issue_mock.assert_not_called()
+        add_work_item_worklog_mock.assert_called_once_with(
+            issue_key_or_id=work_item.key,
+            started=datetime.fromisoformat(screen_result.started).astimezone(timezone.utc),
+            time_spent=screen_result.time_spent,
+            time_remaining=screen_result.time_remaining,
+            comment=screen_result.description,
+            current_remaining_estimate=screen._work_item_time_tracking.remaining_estimate,
+        )
+        fetch_work_logs_mock.assert_has_calls([call()])
+        assert result is None
+
+
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
+@patch.object(APIController, 'update_worklog')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_update_worklog_entry(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    update_worklog_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    screen_result = LogWorkScreenResult(
+        mode=LogWorkScreenMode.UPDATE,
+        worklog_id='1',
+        work_item_key=work_item.key,
+        time_spent='1h',
+        started='2026-01-01 12:30',
+    )
+    update_worklog_mock.return_value = APIControllerResponse()
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        result = await screen._update_worklog_entry('1', screen_result)  # type:ignore[func-returns-value]
+        # THEN
+        get_issue_mock.assert_not_called()
+        update_worklog_mock.assert_called_once_with(
+            issue_key_or_id=work_item.key,
+            worklog_id='1',
+            started=datetime.fromisoformat(screen_result.started).astimezone(timezone.utc),
+            time_spent=screen_result.time_spent,
+            time_remaining=screen_result.time_remaining,
+            comment=screen_result.description,
+            remaining_estimate=screen._work_item_time_tracking.remaining_estimate,
+        )
+        fetch_work_logs_mock.assert_has_calls([call(), call(fetch_time_tracking=True)])
+        assert result is None
+
+
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
+@patch.object(APIController, 'update_worklog')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_update_worklog_entry_without_worklog_id(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    update_worklog_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    screen_result = LogWorkScreenResult(
+        mode=LogWorkScreenMode.UPDATE,
+        worklog_id='1',
+        work_item_key=work_item.key,
+        time_spent='1h',
+        started='2026-01-01 12:30',
+    )
+    update_worklog_mock.return_value = APIControllerResponse()
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        result = await screen._update_worklog_entry('', screen_result)  # type:ignore[func-returns-value]
+        # THEN
+        get_issue_mock.assert_not_called()
+        update_worklog_mock.assert_not_called()
+        fetch_work_logs_mock.assert_has_calls([call()])
+        assert result is None
+
+
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
+@patch.object(APIController, 'remove_worklog')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_delete_log_entry(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    remove_worklog_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    remove_worklog_mock.return_value = APIControllerResponse()
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        result = await screen._delete_log_entry('1')
+        # THEN
+        get_issue_mock.assert_not_called()
+        remove_worklog_mock.assert_called_once_with(work_item.key, '1')
+        fetch_work_logs_mock.assert_has_calls([call(), call(fetch_time_tracking=True)])
+        assert screen._work_logs_deleted is True
+        assert result is None
+
+
+@patch.object(WorkItemWorkLogScreen, '_fetch_work_logs')
+@patch.object(APIController, 'remove_worklog')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_delete_log_entry_fails_to_delete(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    remove_worklog_mock: AsyncMock,
+    fetch_work_logs_mock: AsyncMock,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(logs=[], max_results=0, start_at=0, total=0)
+    )
+    remove_worklog_mock.return_value = APIControllerResponse(success=False)
+    async with app.run_test():
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        result = await screen._delete_log_entry('1')
+        # THEN
+        get_issue_mock.assert_not_called()
+        remove_worklog_mock.assert_called_once_with(work_item.key, '1')
+        fetch_work_logs_mock.assert_has_calls([call()])
+        assert screen._work_logs_deleted is False
+        assert result is None
+
+
+@patch.object(JiraApp, 'open_url')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_open_url(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    open_url_mock: Mock,
+    jira_issues,
+    mock_configuration,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(
+            logs=[
+                JiraWorklog(id='1', issue_id=work_item.id, author=work_item.reporter),
+            ],
+            max_results=1,
+            start_at=0,
+            total=1,
+        )
+    )
+    mock_configuration.jira_base_url = 'http://foo.bar'
+    async with app.run_test() as pilot:
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await pilot.press('tab')
+        await pilot.press('ctrl+o')
+        # THEN
+        get_issue_mock.assert_not_called()
+        assert screen._work_item_time_tracking == work_item.time_tracking
+        assert screen.query_one('#time-tracking-container', Horizontal) is not None
+        get_work_item_worklog_mock.assert_called_once_with('key-2')
+        assert len(screen.work_log_items_container.children) == 1
+        open_url_mock.assert_called_once()
+
+
+@patch.object(JiraApp, 'open_url')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_edit_entry(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    open_url_mock: Mock,
+    jira_issues,
+    mock_configuration,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(
+            logs=[
+                JiraWorklog(id='1', issue_id=work_item.id, author=work_item.reporter),
+            ],
+            max_results=1,
+            start_at=0,
+            total=1,
+        )
+    )
+    mock_configuration.jira_base_url = 'http://foo.bar'
+    async with app.run_test() as pilot:
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await pilot.press('tab')
+        await pilot.press('ctrl+e')
+        # THEN
+        get_issue_mock.assert_not_called()
+        assert screen._work_item_time_tracking == work_item.time_tracking
+        assert screen.query_one('#time-tracking-container', Horizontal) is not None
+        get_work_item_worklog_mock.assert_called_once_with('key-2')
+        assert len(screen.work_log_items_container.children) == 1
+        assert isinstance(app.screen, LogWorkScreen)
+
+
+@patch.object(WorkLogCollapsible, '_edit_worklog_entry')
+@patch.object(APIController, 'get_work_item_worklog')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_work_log_screen_edit_entry_press_save(
+    get_issue_mock: AsyncMock,
+    get_work_item_worklog_mock: AsyncMock,
+    edit_worklog_entry_mock: AsyncMock,
+    jira_issues,
+    mock_configuration,
+    app,
+):
+    # GIVEN
+    work_item = jira_issues[1]
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[work_item])
+    )
+    get_work_item_worklog_mock.return_value = APIControllerResponse(
+        result=PaginatedJiraWorklog(
+            logs=[
+                JiraWorklog(id='1', issue_id=work_item.id, author=work_item.reporter),
+            ],
+            max_results=1,
+            start_at=0,
+            total=1,
+        )
+    )
+    mock_configuration.jira_base_url = 'http://foo.bar'
+    async with app.run_test() as pilot:
+        await app.push_screen(WorkItemWorkLogScreen(work_item.key, work_item.time_tracking))
+        screen = cast('WorkItemWorkLogScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await pilot.press('tab')
+        await pilot.press('ctrl+e')
+        await pilot.press('1')
+        await pilot.press('h')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('a')
+        await pilot.press('tab')
+        await pilot.press('enter')
+        # THEN
+        get_issue_mock.assert_not_called()
+        assert screen._work_item_time_tracking == work_item.time_tracking
+        assert screen.query_one('#time-tracking-container', Horizontal) is not None
+        get_work_item_worklog_mock.assert_called_once_with('key-2')
+        assert len(screen.work_log_items_container.children) == 1
+        assert isinstance(app.screen, WorkItemWorkLogScreen)
+        edit_worklog_entry_mock.assert_called_once()

--- a/src/jiratui/widgets/work_item_details/work_log.py
+++ b/src/jiratui/widgets/work_item_details/work_log.py
@@ -1,4 +1,7 @@
-from datetime import datetime
+import dataclasses
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
 import re
 from typing import cast
 
@@ -6,7 +9,7 @@ from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import ItemGrid, Vertical, VerticalScroll
+from textual.containers import Horizontal, ItemGrid, Vertical, VerticalScroll
 from textual.message import Message
 from textual.screen import Screen
 from textual.widgets import (
@@ -22,14 +25,51 @@ from textual.widgets import (
 )
 
 from jiratui.api_controller.controller import APIControllerResponse
-from jiratui.models import JiraWorklog, PaginatedJiraWorklog
+from jiratui.models import (
+    JiraIssue,
+    JiraIssueSearchResponse,
+    JiraWorklog,
+    PaginatedJiraWorklog,
+    TimeTracking,
+)
 from jiratui.utils.urls import build_external_url_for_work_log
 from jiratui.widgets.base import DateInput
+from jiratui.widgets.work_item_details.fields import TimeTrackingWidget
+
+
+class LogWorkScreenMode(Enum):
+    """The modes supported by the screen that allows users to add/update work log entries."""
+
+    CREATE = 'create'
+    UPDATE = 'update'
+
+
+@dataclass()
+class LogWorkScreenResult:
+    """The data returned by the screen that allows users to add/update work log entries."""
+
+    work_item_key: str
+    mode: LogWorkScreenMode
+    time_spent: str
+    started: str
+    time_remaining: str | None = None
+    description: str | None = None
+    worklog_id: str | None = None
 
 
 class WorkLogCollapsible(Collapsible):
     """A collapsible widget to display information of a worklog and to handle opening the worklog details in the
-    browser and deleting work logs."""
+    browser and deleting work logs.
+
+    This widget is responsible for:
+    - posting a message [LogEntryDeleted](#jiratui.widgets.work_item_details.work_log.WorkLogCollapsible.LogEntryDeleted)
+    when a worklog entry is deleted after the user presses `d`.
+    - opening the screen [LogWorkScreen](#jiratui.widgets.work_item_details.work_log.LogWorkScreen) to allow the user to
+    update a worklog entry after the user presses `^e`.
+    - posting a message [UpdateLogEntry](#jiratui.widgets.work_item_details.work_log.WorkLogCollapsible.UpdateLogEntry)
+    when the user wants to update a worklog entry. The handler will take care of making the update.
+    - opening a worklog entry's URL in the browser when the user presses `^o`.
+    """
 
     BINDINGS = [
         Binding(
@@ -41,71 +81,139 @@ class WorkLogCollapsible(Collapsible):
         Binding(
             key='d',
             action='delete_worklog',
-            description='Delete Worklog',
+            description='Delete',
+            show=True,
+        ),
+        Binding(
+            key='ctrl+e',
+            action='edit_worklog_entry',
+            description='Edit',
             show=True,
         ),
     ]
 
-    class Deleted(Message):
-        """A worklog is deleted."""
+    @dataclass
+    class LogEntryDeleted(Message):
+        """A message to request the handler to delete a worklog entry."""
 
-        pass
+        worklog_id: str
+
+    @dataclass
+    class UpdateLogEntry(Message):
+        """A message to request the handler to update a worklog entry."""
+
+        worklog_id: str
+        work_item_key: str
+        time_spent: str
+        time_remaining: str
+        started: str
+        description: str | None = None
+        mode: LogWorkScreenMode = LogWorkScreenMode.UPDATE
+
+        def as_dict(self) -> dict:
+            return dataclasses.asdict(self)
 
     def __init__(self, *args, **kwargs):
         self._url = kwargs.pop('url')
-        self._worklog_id = kwargs.pop('worklog_id')
+        self._worklog_id: str = kwargs.pop('worklog_id')
         self._work_item_key = kwargs.pop('work_item_key')
+        self._worklog_time_spent = kwargs.pop('worklog_time_spent', '') or ''
+        self._worklog_date_started = kwargs.pop('worklog_date_started', '') or ''
+        self._worklog_time_remaining = kwargs.pop('worklog_time_remaining', '') or ''
+        self._worklog_description = kwargs.pop('worklog_description', '') or ''
         super().__init__(*args, **kwargs)
 
     def action_open_in_browser(self) -> None:
         """Opens the worklog in the default browser."""
+
         if self._url:
             self.app.open_url(self._url)
 
     def action_delete_worklog(self):
-        """Attempts to delete the worklog."""
-        if self._worklog_id:
-            self.run_worker(self._delete_worklog)
+        """Posts a message to request deleting a work log entry."""
 
-    async def _delete_worklog(self) -> None:
-        """Deletes a worklog."""
-        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
-        response: APIControllerResponse = await application.api.remove_worklog(
-            self._work_item_key, self._worklog_id
-        )
-        if response.success:
-            self.notify('Worklog deleted', title='Worklog')
-            self.styles.display = 'none'
-            # notify the parents to update necessary information after deleting a worklog
-            self.post_message(self.Deleted())
-        else:
-            self.notify(
-                f'Failed to delete the worklog: {response.error}', title='Worklog', severity='error'
+        if self._worklog_id:
+            self.post_message(self.LogEntryDeleted(self._worklog_id))
+
+    def action_edit_worklog_entry(self) -> None:
+        """Opens a [LogWorkScreen](#jiratui.widgets.work_item_details.work_log.WorkLogCollapsible.LogWorkScreen) to
+        allow the user to update a log entry.
+
+        Returns:
+            None
+        """
+
+        if self._worklog_id and self._work_item_key:
+            self.app.push_screen(
+                LogWorkScreen(
+                    self._work_item_key,
+                    mode=LogWorkScreenMode.UPDATE,
+                    worklog_id=self._worklog_id,
+                    current_time_spent=self._worklog_time_spent,
+                    current_date_started=self._worklog_date_started,
+                    current_remaining_estimate=self._worklog_time_remaining,
+                    current_description=self._worklog_description,
+                ),
+                callback=self._edit_worklog_entry,
+            )
+
+    async def _edit_worklog_entry(self, data: LogWorkScreenResult | None) -> None:
+        if data:
+            self.post_message(
+                self.UpdateLogEntry(
+                    mode=data.mode,
+                    work_item_key=self._work_item_key,
+                    worklog_id=self._worklog_id,
+                    time_spent=data.time_spent,
+                    time_remaining=data.time_remaining,
+                    started=data.started,
+                    description=data.description,
+                )
             )
 
 
 class WorkItemWorkLogScreen(Screen[dict]):
-    """A screen that displays the work logs of a work item."""
+    """A screen that displays the work logs of a work item.
+
+    This screen is responsible for:
+
+    - fetching the logs associated to the selected work item and displaying them.
+    - optionally fetching the work item's current remaining time estimate; the data is not passed to the screen.
+    - allowing the user to add and delete work logs.
+    - opening the screen [LogWorkScreen](#jiratui.widgets.work_item_details.work_log.LogWorkScreen) when the user
+    presses `n` to add a new log entry.
+    - handling the message [UpdateLogEntry](#jiratui.widgets.work_item_details.work_log.WorkLogCollapsible.UpdateLogEntry)
+    when the user updates a log entry.
+    - handling the message [LogEntryDeleted](#jiratui.widgets.work_item_details.work_log.WorkLogCollapsible.LogEntryDeleted)
+    when the user deletes a log entry.
+
+    The screen can be dismissed with dictionary. This dict can contain a key called `work_logs_deleted` to indicate to
+    the caller that at least 1 worklog has been deleted. This lets the caller refresh the work item (if needed) to
+    reflect the changes to the remaining time estimate.
+    """
 
     HELP = 'See Worklogs section in the help'
-    DEFAULT_CSS = """
-    WorkItemWorkLogScreen > Vertical > Label {
-        color: $accent;
-    }
-    """
     BINDINGS = [
         ('escape', 'close_screen', 'Close'),
+        Binding(
+            key='n',
+            action='log_work',
+            description='Log Work',
+            show=True,
+        ),
     ]
     TITLE = 'Worklog'
 
-    def __init__(self, work_item_key: str):
+    def __init__(self, work_item_key: str, time_tracking: TimeTracking | None = None):
         super().__init__()
         self._work_item_key = work_item_key
+        self._work_item_time_tracking = time_tracking
         self._worklog_counter = 0
         self._worklog_total_count = 0
         # True when at least 1 work log was deleted; useful for refreshing the details of the work item after this
         # screen is dismissed
         self._work_logs_deleted = False
+        self._log_entries: dict[str, WorkLogCollapsible] = {}
 
     @property
     def help_anchor(self) -> str:
@@ -123,22 +231,103 @@ class WorkItemWorkLogScreen(Screen[dict]):
         vertical = Vertical()
         vertical.border_title = f'{self.TITLE} - {self._work_item_key}'
         with vertical:
+            yield Horizontal(id='time-tracking-container', classes='time-tracking-container')
             yield VerticalScroll()
-        yield Footer(show_command_palette=False)
+        yield Footer(show_command_palette=False, compact=True)
 
-    async def on_mount(self) -> None:
+    def on_mount(self) -> None:
         if self._work_item_key:
-            self.run_worker(self.fetch_work_log())
+            self.run_worker(self._fetch_work_logs())
 
-    def on_work_log_collapsible_deleted(self, message: WorkLogCollapsible.Deleted) -> None:
-        """Refreshes the subtitle of the main container to reflect the number of work logs remaining after
-        deleting one."""
-        self._update_subtitle(True)
-        self._work_logs_deleted = True
-        message.stop()
+    async def _fetch_work_logs(self, fetch_time_tracking: bool = False) -> None:
+        """Retrieves the work log data associated to a work item and updates the details in the screen.
 
-    def action_close_screen(self) -> None:
-        self.dismiss({'work_logs_deleted': self._work_logs_deleted})
+        This sends a request to the Jira API to retrieve the worklog details of the work item. If the work item has
+        worklog entries then this method will build a dictionary of
+        [WorkLogCollapsible](#jiratui.widgets.work_item_details.work_log.WorkLogCollapsible) and mounts the values on
+        the screen.
+
+        This method also update the counters displayed in the container's border's subtitle.
+
+        Returns:
+            None
+        """
+
+        await self.work_log_items_container.remove_children(WorkLogCollapsible)
+        self._log_entries = {}
+
+        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
+
+        if self._work_item_time_tracking is None or fetch_time_tracking:
+            # fetch the work item's time tracking information
+            work_item_response: APIControllerResponse = await application.api.get_issue(
+                issue_id_or_key=self._work_item_key,
+            )
+            if not work_item_response.success or not work_item_response.result:
+                self.notify(
+                    f'Unable to find the work item with key {self._work_item_key}',
+                    title='Not Found',
+                    severity='warning',
+                )
+            else:
+                work_item_result: JiraIssueSearchResponse = work_item_response.result
+                work_item: JiraIssue = work_item_result.issues[0]
+                self._work_item_time_tracking = work_item.time_tracking
+
+        # set time tracking
+        self.call_next(self._set_time_tracking_information)
+
+        # retrieve the work logs of the item
+        response: APIControllerResponse = await application.api.get_work_item_worklog(
+            self._work_item_key
+        )
+        result: PaginatedJiraWorklog
+        if response.success and (result := response.result):
+            self._worklog_counter = len(result.logs)
+            self._worklog_total_count = result.total
+            self._update_subtitle()
+
+            worklog: JiraWorklog
+            for worklog in result.logs:
+                self._log_entries[worklog.id] = self._build_work_log_collapsible(worklog)
+
+            await self.work_log_items_container.mount_all(self._log_entries.values())
+
+    async def _set_time_tracking_information(self) -> None:
+        container = self.query_one('#time-tracking-container', Horizontal)
+        await container.remove_children(TimeTrackingWidget)
+        await container.mount(
+            TimeTrackingWidget(
+                original_estimate=(
+                    self._work_item_time_tracking.original_estimate
+                    if self._work_item_time_tracking
+                    else None
+                ),
+                original_estimate_seconds=(
+                    self._work_item_time_tracking.original_estimate_seconds
+                    if self._work_item_time_tracking
+                    else None
+                ),
+                remaining_estimate=(
+                    self._work_item_time_tracking.remaining_estimate
+                    if self._work_item_time_tracking
+                    else None
+                ),
+                remaining_estimate_seconds=(
+                    self._work_item_time_tracking.remaining_estimate_seconds
+                    if self._work_item_time_tracking
+                    else None
+                ),
+                time_spent=self._work_item_time_tracking.time_spent
+                if self._work_item_time_tracking
+                else None,
+                time_spent_seconds=(
+                    self._work_item_time_tracking.time_spent_seconds
+                    if self._work_item_time_tracking
+                    else None
+                ),
+            )
+        )
 
     def _update_subtitle(self, update_counters: bool = False) -> None:
         if update_counters:
@@ -150,126 +339,272 @@ class WorkItemWorkLogScreen(Screen[dict]):
             f'Showing {self._worklog_counter} of {self._worklog_total_count}'
         )
 
-    async def fetch_work_log(self) -> None:
-        """Retrieves the work log data associated to a work item and updates the details in the screen.
+    def _build_work_log_collapsible(self, worklog: JiraWorklog) -> WorkLogCollapsible:
+        url = build_external_url_for_work_log(self._work_item_key, worklog.id)
 
-        Returns:
-            `None`.
+        work_log_details: DataTable = DataTable(
+            cursor_type='row', show_header=False, classes='worklog-details-table'
+        )
+        work_log_details.add_columns(*('Property', 'Value'))
+        work_log_details.add_rows(
+            [
+                (
+                    Text('Time Spent', justify='right'),
+                    Text(worklog.display_time_spent(), justify='left'),
+                ),
+                (
+                    Text('Started', justify='right'),
+                    Text(worklog.display_started(), justify='left'),
+                ),
+                (
+                    Text('Author', justify='right'),
+                    Text(worklog.display_author(), justify='left'),
+                ),
+                (
+                    Text('Update Author', justify='right'),
+                    Text(worklog.display_update_author(), justify='left'),
+                ),
+            ]
+        )
+
+        comment_widget: Markdown | Static
+        if worklog.comment and (comment_text := worklog.get_comment()):
+            comment_widget = Markdown(comment_text)
+        elif worklog.comment:
+            # this may happen if we fail to parse the ADF data for Jira Cloud API
+            comment_widget = Static(
+                Text(
+                    'Unable to display the comment associated to the worklog.',
+                    style='red italic',
+                )
+            )
+        else:
+            comment_widget = Static()
+
+        return WorkLogCollapsible(
+            comment_widget,
+            work_log_details,
+            title=worklog.display(),
+            url=url or None,
+            worklog_id=worklog.id,
+            work_item_key=self._work_item_key,
+            worklog_time_spent=worklog.time_spent,
+            worklog_date_started=worklog.get_date_started(),
+            worklog_time_remaining=self._work_item_time_tracking.remaining_estimate,
+            worklog_description=worklog.get_comment(),
+        )
+
+    def action_close_screen(self) -> None:
+        self.dismiss({'work_logs_deleted': self._work_logs_deleted})
+
+    def action_log_work(self) -> None:
+        if self._work_item_key:
+            self.app.push_screen(
+                LogWorkScreen(
+                    self._work_item_key,
+                    current_remaining_estimate=self._work_item_time_tracking.remaining_estimate,
+                ),
+                callback=self._log_work,
+            )
+
+    @on(WorkLogCollapsible.UpdateLogEntry)
+    async def _request_log_entry_update(self, event: WorkLogCollapsible.UpdateLogEntry) -> None:
+        await self._log_work(
+            LogWorkScreenResult(
+                work_item_key=self._work_item_key,
+                mode=event.mode,
+                time_spent=event.time_spent,
+                started=event.started,
+                description=event.description,
+                time_remaining=event.time_remaining,
+                worklog_id=event.worklog_id,
+            )
+        )
+        event.stop()
+
+    async def _log_work(self, data: LogWorkScreenResult):
+        if data:
+            if data.mode == LogWorkScreenMode.CREATE:
+                await self._add_worklog_entry(work_item_key=self._work_item_key, data=data)
+            elif data.mode == LogWorkScreenMode.UPDATE:
+                await self._update_worklog_entry(worklog_id=data.worklog_id, data=data)
+
+    async def _add_worklog_entry(self, work_item_key: str, data: LogWorkScreenResult) -> None:
+        """Logs work for a work item.
+
+        Return:
+            None
         """
 
-        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
-        response: APIControllerResponse = await application.api.get_work_item_worklog(
-            self._work_item_key
-        )
-        result: PaginatedJiraWorklog
-        if response.success and (result := response.result):
-            self._worklog_counter = len(result.logs)
-            self._worklog_total_count = result.total
-            self._update_subtitle()
-            elements: list[WorkLogCollapsible] = []
-            worklog: JiraWorklog
-            comment_widget: Markdown | Static
-            for worklog in result.logs:
-                if worklog.comment and (comment_text := worklog.get_comment()):
-                    comment_widget = Markdown(comment_text)
-                else:
-                    # this may happen if we fail to parse the ADF data for Jira Cloud API
-                    comment_widget = Static(
-                        Text(
-                            'Unable to display the description associated to the worklog.',
-                            style='red italic',
-                        )
-                    )
+        if not work_item_key:
+            self.notify('Select a work item before logging work.', title='Validation Error')
+            return None
 
-                url = build_external_url_for_work_log(self._work_item_key, worklog.id)
-                work_log_details: DataTable = DataTable(
-                    cursor_type='row', show_header=False, classes='worklog-details-table'
-                )
-                work_log_details.add_columns(*('Property', 'Value'))
-                work_log_details.add_rows(
-                    [
-                        (
-                            Text('Time Spent', justify='right'),
-                            Text(worklog.display_time_spent(), justify='left'),
-                        ),
-                        (
-                            Text('Started', justify='right'),
-                            Text(worklog.display_started(), justify='left'),
-                        ),
-                        (
-                            Text('Author', justify='right'),
-                            Text(worklog.display_author(), justify='left'),
-                        ),
-                        (
-                            Text('Update Author', justify='right'),
-                            Text(worklog.display_update_author(), justify='left'),
-                        ),
-                    ]
-                )
-                elements.append(
-                    WorkLogCollapsible(
-                        comment_widget,
-                        work_log_details,
-                        title=worklog.display(),
-                        url=url or None,
-                        worklog_id=worklog.id,
-                        work_item_key=self._work_item_key,
-                    )
-                )
-            await self.work_log_items_container.mount_all(elements)
+        if not data.time_spent:
+            # this should not happen but if for some reason it does then make sure to let the user know that we can't
+            # add the worklog
+            self.notify(
+                'You need to provide the time spent on the task to log work',
+                title='Validation Error',
+            )
+            return None
+
+        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
+
+        started_datetime: datetime | None = None
+        if data.started:
+            naive_dt = datetime.fromisoformat(data.started)
+            # assume the date/time value is in local time and convert to UTC
+            started_datetime = naive_dt.replace(
+                tzinfo=None
+            ).astimezone()  # make it aware of local TZ as defined by the OS
+            started_datetime = started_datetime.astimezone(timezone.utc)
+
+        response: APIControllerResponse = await application.api.add_work_item_worklog(
+            issue_key_or_id=self._work_item_key,
+            started=started_datetime,
+            time_spent=data.time_spent,
+            time_remaining=data.time_remaining,
+            comment=data.description,
+            current_remaining_estimate=self._work_item_time_tracking.remaining_estimate,
+        )
+        if response.success:
+            self.notify(f'Logged time to task {self._work_item_key}')
+            # a new entry was added; update the time estimate of the work item and the list of logs in the screen
+            await self._fetch_work_logs(fetch_time_tracking=True)
+        else:
+            self.notify(
+                f'Failed to log time to task {self._work_item_key}: {response.error}',
+                severity='error',
+            )
+        return None
+
+    async def _update_worklog_entry(self, worklog_id: str, data: LogWorkScreenResult) -> None:
+        """Attempts to update a work log entry using the Jira API.
+
+        Returns:
+            None
+        """
+
+        if not worklog_id:
+            return None
+
+        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
+
+        started_datetime: datetime | None = None
+        if data.started:
+            naive_dt = datetime.fromisoformat(data.started)
+            # assume the date/time value is in local time and convert to UTC
+            started_datetime = naive_dt.replace(
+                tzinfo=None
+            ).astimezone()  # make it aware of local TZ as defined by the OS
+            started_datetime = started_datetime.astimezone(timezone.utc)
+
+        # request the API to update the worklog entry
+        response: APIControllerResponse = await application.api.update_worklog(
+            issue_key_or_id=self._work_item_key,
+            worklog_id=worklog_id,
+            started=started_datetime,
+            time_spent=data.time_spent,
+            time_remaining=data.time_remaining,
+            comment=data.description,
+            remaining_estimate=self._work_item_time_tracking.remaining_estimate,
+        )
+
+        if response.success:
+            self.notify(f'Logged time to task {self._work_item_key}', title='Worklog')
+            # an entry was updated; update the time estimate of the work item and the list of logs in the screen
+            await self._fetch_work_logs(fetch_time_tracking=True)
+        else:
+            self.notify('There was an error updating the log entry', severity='error')
+        return None
+
+    @on(WorkLogCollapsible.LogEntryDeleted)
+    def _delete_worklog_entry(self, event: WorkLogCollapsible.LogEntryDeleted) -> None:
+        """Deletes a worklog.
+
+        Args:
+            event:
+
+        Returns:
+
+        """
+
+        self.notify('Deleting worklog entry...')
+        self.run_worker(self._delete_log_entry(event.worklog_id))
+        event.stop()
+
+    async def _delete_log_entry(self, worklog_id: str):
+        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
+        response: APIControllerResponse = await application.api.remove_worklog(
+            self._work_item_key, worklog_id
+        )
+        if response.success:
+            self.notify('Worklog deleted', title='Worklog')
+            self._update_subtitle(True)
+            self._work_logs_deleted = True
+            await self._fetch_work_logs(fetch_time_tracking=True)
+        else:
+            self.notify(
+                f'Failed to delete the worklog: {response.error}', title='Worklog', severity='error'
+            )
 
 
 class TimeSpentInput(Input):
-    def __init__(self):
-        super().__init__(placeholder='E.g. 1w 1d', valid_empty=False, classes='required')
+    """An input field that contains a string representing the time spent by the user in a task."""
+
+    def __init__(self, initial_value: str | None = None):
+        super().__init__(
+            value=initial_value or '',
+            placeholder='E.g. 1w 1d',
+            valid_empty=False,
+            classes='required',
+        )
         self.border_title = 'Time Spent'
         self.border_subtitle = '(*)'
         self.tooltip = 'Enter the amount of time you work on this task'
 
 
 class TimeRemainingInput(Input):
+    """An input field that contains a string representing the time remaining in a task."""
+
     def __init__(self, initial_value: str | None = None):
-        super().__init__(value=initial_value, placeholder='E.g. 1d 1h 30m')
+        super().__init__(value=initial_value or '', placeholder='E.g. 1d 1h 30m')
         self.border_title = 'Time Remaining'
         self.tooltip = 'Optionally, enter the time remaining in the task'
 
 
 class LogDateTimeInput(DateInput):
+    """An DateInput field that contains a string representing the date/time when the user did work on a task."""
+
     TEMPLATE = '9999-99-99 99:99'
     PLACEHOLDER = '2025-10-12 13:50'
 
-    def __init__(self):
+    def __init__(self, initial_value: str | None = None):
         super().__init__(valid_empty=False)
         self.disabled = True
         self.border_title = 'Date Started'
         self.tooltip = 'Enter the date/time on which the work was done'
-        self.value = datetime.now().strftime('%Y-%m-%d %H:%M')
+        self.value = initial_value or datetime.now().strftime('%Y-%m-%d %H:%M')
 
 
 class WorkDescription(TextArea):
-    def __init__(self):
-        super().__init__()
+    """A textarea field that contains an optional comment for a work log entry."""
+
+    def __init__(self, initial_value: str | None = None):
+        super().__init__(text=initial_value or '')
         self.disabled = True
         self.border_title = 'Work Description'
         self.compact = True
         self.tooltip = 'Add an optional description'
 
 
-class LogWorkScreen(Screen[dict]):
-    """A modal screen to allow the user to log work for a work item.
+class LogWorkScreen(Screen[LogWorkScreenResult | None]):
+    """A modal screen that allow users to provide data for creating new work log entries or updating an existing entry.
 
-    The screen's result is a dictionary with the following keys:
-
-    ```python
-    {
-        'key': the key of the issue whose work lo we are updating.
-        'time_spent': the time spent as provided by the user in the screen's form.
-        'time_remaining': the time remaining as provided by the user in the screen's form.
-        'description': an optional as provided by the user in the screen's form.
-        'started': an optional datetime string.
-        'current_remaining_estimate': the issue's current remaining time.
-    }
-    ```
+    The screen's result is an instance of
+    [LogWorkScreenResult](#jiratui.widgets.work_item_details.work_log.LogWorkScreenResult). The object contains the
+    values to add or update a work log entry
 
     **See Also**:
     - [Use Case: Log Work](#use-case-log-work)
@@ -279,10 +614,26 @@ class LogWorkScreen(Screen[dict]):
         ('escape', 'app.pop_screen', 'Close'),
     ]
 
-    def __init__(self, work_item_key: str, current_remaining_estimate: str | None = None):
+    def __init__(
+        self,
+        work_item_key: str,
+        mode: LogWorkScreenMode = LogWorkScreenMode.CREATE,
+        worklog_id: str | None = None,
+        current_remaining_estimate: str | None = None,
+        current_time_spent: str | None = None,
+        current_date_started: str | None = None,
+        current_description: str | None = None,
+    ):
         super().__init__()
         self._work_item_key = work_item_key
+        self._worklog_id = worklog_id
         self._current_remaining_estimate = current_remaining_estimate
+        self._current_time_spent = current_time_spent
+        self._current_date_started = current_date_started
+        self._current_description = current_description
+        self._mode = mode
+        if self._mode == LogWorkScreenMode.UPDATE and not self._worklog_id:
+            raise ValueError('Missing worklog Id for update.')
 
     @property
     def work_log_items_container(self) -> VerticalScroll:
@@ -313,12 +664,12 @@ class LogWorkScreen(Screen[dict]):
         vertical.border_title = f'Log Work - {self._work_item_key}'
         with vertical:
             with ItemGrid(classes='log-work-time-input-grid'):
-                yield TimeSpentInput()
+                yield TimeSpentInput(initial_value=self._current_time_spent)
                 yield TimeRemainingInput(initial_value=self._current_remaining_estimate)
             with ItemGrid(classes='log-work-date-hint-grid'):
-                yield LogDateTimeInput()
+                yield LogDateTimeInput(initial_value=self._current_date_started)
                 yield Label('w = week | d = day | h = hour | m = minutes')
-            yield WorkDescription()
+            yield WorkDescription(initial_value=self._current_description)
             with ItemGrid(classes='log-work-buttons-grid'):
                 yield Button(
                     'Save', variant='success', id='log-work-button-save', disabled=True, flat=True
@@ -438,21 +789,22 @@ class LogWorkScreen(Screen[dict]):
 
     @on(Button.Pressed, '#log-work-button-quit')
     def handle_quit_button(self) -> None:
-        self.dismiss({})
+        self.dismiss(None)
 
     @on(Button.Pressed, '#log-work-button-save')
     def handle_save_button(self) -> None:
         self.dismiss(
-            {
-                'key': self._work_item_key,
-                'time_spent': self.time_spent_input.value,
-                'time_remaining': self.time_remaining_input.value,
-                'description': self.work_description_input.text,
-                'started': (
+            LogWorkScreenResult(
+                work_item_key=self._work_item_key,
+                mode=self._mode,
+                worklog_id=self._worklog_id,
+                time_spent=self.time_spent_input.value,
+                time_remaining=self.time_remaining_input.value,
+                description=self.work_description_input.text,
+                started=(
                     self.log_date_time_input.value.replace(' ', 'T')
                     if self.log_date_time_input.value
                     else None
                 ),
-                'current_remaining_estimate': self._current_remaining_estimate,
-            }
+            )
         )

--- a/uv.lock
+++ b/uv.lock
@@ -307,14 +307,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -768,12 +768,12 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.4.1,<9.0.0" },
+    { name = "click", specifier = ">=8.4.2,<9.0.0" },
     { name = "gitpython", specifier = ">=3.1.47,<3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "marklas", specifier = "==0.8.0" },
+    { name = "marklas", specifier = "==0.8.1" },
     { name = "puremagic", specifier = ">=2.2.0,<3.0.0" },
-    { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.14.0,<3.0.0" },
+    { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.14.2,<3.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-json-logger", specifier = ">=4.1.0,<5.0.0" },
     { name = "textual", extras = ["syntax"], specifier = ">=8.2.7,<9.0.0" },
@@ -801,10 +801,10 @@ docs = [
 lint = [
     { name = "import-linter", specifier = ">=2.11" },
     { name = "mypy", specifier = ">=2.1.0,<3.0.0" },
-    { name = "ruff", specifier = ">=0.15.14,<0.16.0" },
+    { name = "ruff", specifier = ">=0.15.20,<0.16.0" },
 ]
 test = [
-    { name = "pytest", specifier = ">=9.1.0,<10.0.0" },
+    { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0,<2.0.0" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8.0.0" },
     { name = "respx", specifier = ">=0.23.1" },
@@ -901,14 +901,14 @@ linkify = [
 
 [[package]]
 name = "marklas"
-version = "0.8.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mistune" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/82/4e08ee4f5db77c96dc53c892d254509bf8b62cd0b9f5aabc1a390b61b708/marklas-0.8.0.tar.gz", hash = "sha256:d2f75d1077be269156fe970795a77e8420b9738bc1bf24fd0e3c416057abc784", size = 47459, upload-time = "2026-05-31T15:10:30.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/bf/52fcd6f3c830003e69ef88675285006afd20f38000091da29a5c05348cc4/marklas-0.8.1.tar.gz", hash = "sha256:42eae648e291b9117008b97c2d43c9e4efba15bca85b63b9433e977308f3b719", size = 48148, upload-time = "2026-06-23T02:50:15.85Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/49/5fd7466597259bff1fddc813bf0f95341e0e1ce65920a0d26d92a3b9d8b0/marklas-0.8.0-py3-none-any.whl", hash = "sha256:c84e4658cd344c2e5ffb8a6fe9a76b43aef3c07ab4a9fa51aa2da0786db32829", size = 55955, upload-time = "2026-05-31T15:10:28.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/89/37b11718a56b6ec07cda663e6b7cf10a4005666ee6ef369e25f4173054d8/marklas-0.8.1-py3-none-any.whl", hash = "sha256:ab85f3d15d7371f77904bacfd5173cd713e723ab5394e11510c68e59dbc8a68a", size = 56523, upload-time = "2026-06-23T02:50:14.392Z" },
 ]
 
 [[package]]
@@ -972,11 +972,11 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/5f/007786743f962224423753b78f7d7acb0f2ade46d1604f2e0fa2bedf9020/mistune-3.3.2.tar.gz", hash = "sha256:e12ee4f1e74336e91aa1141e35f913b337c40bdf7c0cc49f21fb853a27e8b62f", size = 111284, upload-time = "2026-06-23T00:29:28.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl", hash = "sha256:a678a56387d487db7368ede4647cb2ba1deff22ce61f92343e4ebe0ddfce4f2d", size = 61554, upload-time = "2026-06-23T00:29:27.088Z" },
 ]
 
 [[package]]
@@ -1507,16 +1507,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [package.optional-dependencies]
@@ -1535,7 +1535,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1544,9 +1544,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1696,27 +1696,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.14"
+version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
-    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
-    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
-    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
-    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
-    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR enhances the screen used for logging work into a work item.

The screen that shows the entries now allows the user to press `n` to add a new entry and, by pressing `^e` the user can edit an existing entry.

> [!WARNING]
> This PR deprecates the keybind `^t` to add new log entries. Instead, the user can now use `^l`. The binding 
> will temporarily open the log view but it will be removed in a future release.


**The screen that shows the log entries for a work item**

<img width="935" height="646" alt="Screenshot 2026-06-26 at 18 43 25" src="https://github.com/user-attachments/assets/55a99ed8-8650-4cfc-8a4b-5cb4e577c20f" />

**The screen to edit an entry**

<img width="934" height="648" alt="Screenshot 2026-06-26 at 18 43 44" src="https://github.com/user-attachments/assets/2e543f4c-2153-4a6a-8919-bf6a8da75eab" />

**The screen to edit an entry**

<img width="934" height="648" alt="Screenshot 2026-06-26 at 18 43 44" src="https://github.com/user-attachments/assets/2e543f4c-2153-4a6a-8919-bf6a8da75eab" />

Solves https://github.com/whyisdifficult/jiratui/issues/214
Closes https://github.com/whyisdifficult/jiratui/issues/214