### PR TITLE
JT-49: Define and use EmptyTextAreaStaticWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DEPRECATED**: pressing `^t` after selecting an item will no longer open the modal to log work for the item. Instead,
 it will open the modal screen that displays the item's work log entries. The keybind `^t` will be removed in future
 versions. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/282
+- Adds a new widget called `EmptyTextAreaStaticWidget` to serve as a container to add the first content of an empty
+textarea-based field in the Info tab. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/286
 
 ### Bug Fixes
 
 - Fixes a bug when the user tries to add a new work log entry and the work item does not have time tracking data set. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/283
+- Fix bugs in tests after fixing issues with the update of textarea-based fields in the Info tab. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/286
+- Fix bug when editing textarea-based fields in the Info tab when the fields do not have content. By [@WangLaoShi](https://github.com/WangLaoShi) in https://github.com/whyisdifficult/jiratui/pull/281
 
 ### Minor Improvements
 
@@ -28,7 +32,9 @@ versions. By [@whyisdifficult](https://github.com/whyisdifficult) in https://git
 - Set `config.enable_goto=True` as default. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/277
 - Bump `click`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/282
 - Bump `pydanticsettings`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/282
-- Bump `marklas`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/282
+- Bump `marklas`. By [@whyisdifficult](https://github.com/whyisdifficult) in
+  - https://github.com/whyisdifficult/jiratui/pull/282
+  - https://github.com/whyisdifficult/jiratui/pull/286
 - Bump `pytest`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/282
 - Bump `ruff`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/282
 - Refactor worklog classes to make it possible to reuse some components. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/283

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "click>=8.4.2,<9.0.0",
     "gitpython>=3.1.47,<3.2.0",
     "httpx>=0.28.1",
-    "marklas==0.8.1",
+    "marklas==0.8.2",
     "puremagic>=2.2.0,<3.0.0",
     "pydantic-settings[yaml]>=2.14.2,<3.0.0",
     "python-dateutil>=2.9.0.post0",

--- a/src/jiratui/widgets/commons/widgets.py
+++ b/src/jiratui/widgets/commons/widgets.py
@@ -72,7 +72,7 @@ from textual.binding import Binding
 from textual.events import Key
 from textual.message import Message
 from textual.validation import Number, ValidationResult
-from textual.widgets import Input, MaskedInput, Select, SelectionList, TextArea
+from textual.widgets import Input, MaskedInput, Select, SelectionList, Static, TextArea
 from textual.widgets.selection_list import Selection
 
 from jiratui.widgets.base import DateInput
@@ -1611,6 +1611,26 @@ class ReadOnlyPlainTextTextAreaWidget(TextArea):
     @property
     def field_title(self) -> str:
         return self.__title
+
+
+class EmptyTextAreaStaticWidget(Static):
+    """A Static widget that holds the jira_field_key for updating a text-based field such as description, environment
+    or any other textarea-based custom field.
+
+    This widget is used for displaying a message to the user that the underlying field is empty but to allow the user
+    to edit the field using an editor. The jira_field_key value is used to store the content of the field after the user
+    update its content in the editor.
+    """
+
+    def __init__(
+        self,
+        jira_field_key: str,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.jira_field_key = jira_field_key
+        name = self.name or self.jira_field_key.replace('_', ' ').title()
+        self.content = f'There is no "{name}" set. Press "^e" to edit it.'
 
 
 # ============================================================================

--- a/src/jiratui/widgets/work_item_info/info.py
+++ b/src/jiratui/widgets/work_item_info/info.py
@@ -25,7 +25,10 @@ from jiratui.widgets.commons.factory_utils import (
     FieldMetadata,
     build_read_only_rich_text_widget,
 )
-from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget
+from jiratui.widgets.commons.widgets import (
+    EmptyTextAreaStaticWidget,
+    ReadOnlyPlainTextTextAreaWidget,
+)
 from jiratui.widgets.work_item_info.screens import DisplayTextContentScreen, EditTextContentScreen
 from jiratui.widgets.work_item_info.tabs import InfoTabbedContent, TextAreaTabPane
 
@@ -69,6 +72,13 @@ class WorkItemInfoContainer(Vertical):
 
     @on(InfoTabbedContent.EditContent)
     def _edit_content(self, event: InfoTabbedContent.EditContent) -> None:
+        if not self.issue:
+            self.notify(
+                'No work item is loaded. Select a work item and try again.',
+                severity='error',
+                title='Update Work Item',
+            )
+
         if self._updating_rich_text_is_enabled:
             if self._editor:
                 new_content = self._open_as_temporary_file(self._editor, event.content)
@@ -92,6 +102,7 @@ class WorkItemInfoContainer(Vertical):
 
     def _handle_edit_result(self, data: dict | None) -> None:
         """Receives the result from the built-in editor and schedules the API update."""
+
         if not data:
             return
         if not data.get('jira_field_key'):
@@ -107,14 +118,6 @@ class WorkItemInfoContainer(Vertical):
         """Updates the value of a text-based field in the work item."""
 
         if not data or not data.get('jira_field_key'):
-            return
-
-        if not self.issue:
-            self.notify(
-                'No work item is loaded. Select a work item and try again.',
-                severity='error',
-                title='Update Work Item',
-            )
             return
 
         if self._updating_rich_text_is_enabled:
@@ -193,15 +196,43 @@ class WorkItemInfoContainer(Vertical):
         self.query_one(Rule).visible = False
 
     async def _setup_work_item_description(self, work_item: JiraIssue) -> None:
+        """Sets up the TextAreaTabPane widget that holds and display the work item's description field.
+
+        The type of widget generated and mounted inside the TextAreaTabPane depends on whether the work item's field
+        has data or not and, on whether ADF is supported by the API.
+
+        - If the field does not have data yet then this method will generate a EmptyTextAreaStaticWidget. The widget
+        will simply display a hint to the user and hold the field's key so that the API can update its value.
+        - If the field has data and ADF is supported by the API then this method will build a
+        ReadOnlyADFMarkdownTextAreaWidget. The widget's content will be Markdown rendered from the ADF content of the
+        field.
+        - If the field has data and ADF is not supported by the API then this method will build a
+        ReadOnlyPlainTextTextAreaWidget. The widget's content will be the text content of the field.
+
+        Fields are processed based on the work item's edit-metadata.
+
+        Args:
+          work_item: the work item whose description field we want to display.
+
+        Returns:
+          None
+        """
+
         if issue_edit_metadata := work_item.get_edit_metadata():
             if field_metadata := issue_edit_metadata.get(JiraWorkItemFields.DESCRIPTION.value, {}):
-                field_name = field_metadata.get('name', field_metadata.get('key')).title()
-                widget: ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
+                field_name = field_metadata.get('name') or field_metadata.get('key', 'Description')
+                field_name = field_name.title()
+                widget: (
+                    ReadOnlyADFMarkdownTextAreaWidget
+                    | ReadOnlyPlainTextTextAreaWidget
+                    | EmptyTextAreaStaticWidget
+                )
                 if work_item.rich_text_value_is_empty(work_item.description):  # type:ignore[arg-type]
-                    widget = Static(
-                        f'There is no "{field_name}" set. Press "^e" to edit it.',
-                        classes='tip',
+                    widget = EmptyTextAreaStaticWidget(
+                        jira_field_key=field_metadata.get('key')
+                        or JiraWorkItemFields.DESCRIPTION.value,
                         id=field_metadata.get('key') or JiraWorkItemFields.DESCRIPTION.value,
+                        classes='tip',
                         name=field_name,
                     )
                 else:
@@ -217,6 +248,28 @@ class WorkItemInfoContainer(Vertical):
                 await pane.mount(widget)
 
     async def _refresh_tabs_and_set_work_item(self, work_item: JiraIssue | None):
+        """Updates the content of the Info tab, i.e. its TextAreaTabPane widgets and the summary widget.
+
+        After the user select a work item form the search results the application needs to set up the "Info" tab. This
+        tab contains a series of TextAreaTabPane, each of which holds and display the work' item's textarea-based
+        fields. The info tab also shows holds a widget that displays the summary of the item.
+
+        This method updates the content of the Info tab, i.e. its TextAreaTabPane widgets and the summary widget.
+
+        How the widgets are set up?
+
+        If updating additional fields for a work item is enabled then this method will build a list of widgets to
+        display textarea-based content. Each widget is mounted within a TextAreaTabPane.
+        The type of widget that is generated depends on whether the work item's field has data and, on whether ADF is
+        supported by the API. For more details refer to self._build_textarea_widgets.
+
+        Args:
+            work_item: the instance of the work item whose text-based widgets we want to set up.
+
+        Returns:
+            None
+        """
+
         self._clear_static_widgets()
 
         # re-build the InfoTabbedContent widget by removing it first
@@ -244,16 +297,17 @@ class WorkItemInfoContainer(Vertical):
             # build widgets for the fields with rich-text support
             if self._enable_updating_additional_fields:
                 widgets: list[
-                    ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
+                    ReadOnlyADFMarkdownTextAreaWidget
+                    | ReadOnlyPlainTextTextAreaWidget
+                    | EmptyTextAreaStaticWidget
                 ] = self._build_textarea_widgets(work_item)
                 for widget in widgets:
-                    if isinstance(widget, Static):
+                    if isinstance(widget, EmptyTextAreaStaticWidget):
                         pane_title = widget.name
-                        pane_id = f'pane-{widget.id}'
                     else:
                         pane_title = widget.field_title
-                        pane_id = f'pane-{widget.jira_field_key}'
 
+                    pane_id = f'pane-{widget.jira_field_key}'
                     pane = TextAreaTabPane(title=pane_title, widget_id=pane_id)
                     await self.info_tabbed_content.add_pane(pane)
                     await pane.mount(widget)
@@ -261,9 +315,40 @@ class WorkItemInfoContainer(Vertical):
     def _build_textarea_widgets(
         self,
         work_item: JiraIssue,
-    ) -> list[ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static]:
+    ) -> list[
+        ReadOnlyADFMarkdownTextAreaWidget
+        | ReadOnlyPlainTextTextAreaWidget
+        | EmptyTextAreaStaticWidget
+    ]:
+        """Build a list of widgets to hold and display the value of textarea-based fields.
+
+        The type of widget generated depends on whether the work item's field has data or not and, on whether ADF is
+        supported by the API.
+
+        - If the field does not have data yet then this method will generate a EmptyTextAreaStaticWidget. The widget
+        will simply display a hint to the user and hold the field's key so that the API can update its value.
+        - If the field has data and ADF is supported by the API then this method will build a
+        ReadOnlyADFMarkdownTextAreaWidget. The widget's content will be Markdown rendered from the ADF content of the
+        field.
+        - If the field has data and ADF is not supported by the API then this method will build a
+        ReadOnlyPlainTextTextAreaWidget. The widget's content will be the text content of the field.
+
+        Fields are processed based on the work item's edit-metadata.
+
+        Important: the work item's description field is handled separately. For details
+        see: self._setup_work_item_description
+
+        Args:
+            work_item: the instance of the work item whose text-based widgets we want to set up.
+
+        Returns:
+            A list of ReadOnlyADFMarkdownTextAreaWidget, ReadOnlyPlainTextTextAreaWidget or EmptyTextAreaStaticWidget.
+        """
+
         widgets: list[
-            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
+            ReadOnlyADFMarkdownTextAreaWidget
+            | ReadOnlyPlainTextTextAreaWidget
+            | EmptyTextAreaStaticWidget
         ] = []
         if issue_edit_metadata := work_item.get_edit_metadata():
             ignored_fields = self._update_additional_fields_ignore_ids
@@ -286,36 +371,39 @@ class WorkItemInfoContainer(Vertical):
                 ):
                     field_name = metadata.name or metadata.key.replace('_', ' ').title()
                     textarea_widget: (
-                        ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
+                        ReadOnlyADFMarkdownTextAreaWidget
+                        | ReadOnlyPlainTextTextAreaWidget
+                        | EmptyTextAreaStaticWidget
                     )
                     if metadata.key.lower() == JiraWorkItemFields.ENVIRONMENT.value:
                         if work_item.rich_text_value_is_empty(work_item.environment):  # type:ignore[arg-type]
-                            textarea_widget = Static(
-                                f'There is no "{field_name}" set. Press "^e" to edit it.',
+                            textarea_widget = EmptyTextAreaStaticWidget(
+                                jira_field_key=metadata.key or JiraWorkItemFields.ENVIRONMENT.value,
                                 classes='tip',
-                                id=metadata.key or field_id,
+                                id=metadata.key or JiraWorkItemFields.ENVIRONMENT.value,
                                 name=field_name,
                             )
                         else:
                             textarea_widget = build_read_only_rich_text_widget(
-                                jira_field_key=metadata.key or field_id,
+                                jira_field_key=metadata.key or JiraWorkItemFields.ENVIRONMENT.value,
                                 field_name=field_name,
                                 required=metadata.required,
                                 content=work_item.environment,
                             )
                     else:
+                        # handle any other textarea-based field
                         # get the value of the field
                         field_value: Any | None = work_item.get_custom_field_value(field_id)
                         if work_item.rich_text_value_is_empty(field_value):
-                            textarea_widget = Static(
-                                f'There is no "{field_name}" set. Press "^e" to edit it.',
+                            textarea_widget = EmptyTextAreaStaticWidget(
+                                jira_field_key=metadata.key,
                                 classes='tip',
-                                id=metadata.key or field_id,
+                                id=metadata.key or metadata.field_id,
                                 name=field_name,
                             )
                         else:
                             textarea_widget = build_read_only_rich_text_widget(
-                                jira_field_key=metadata.key or field_id,
+                                jira_field_key=metadata.key or metadata.field_id,
                                 field_name=field_name,
                                 required=metadata.required,
                                 content=field_value,

--- a/src/jiratui/widgets/work_item_info/info.py
+++ b/src/jiratui/widgets/work_item_info/info.py
@@ -403,7 +403,7 @@ class WorkItemInfoContainer(Vertical):
                             )
                         else:
                             textarea_widget = build_read_only_rich_text_widget(
-                                jira_field_key=metadata.key or metadata.field_id,
+                                jira_field_key=metadata.key,
                                 field_name=field_name,
                                 required=metadata.required,
                                 content=field_value,

--- a/src/jiratui/widgets/work_item_info/tests/test_info.py
+++ b/src/jiratui/widgets/work_item_info/tests/test_info.py
@@ -672,21 +672,32 @@ async def test_work_item_info_container_clear_information(
 @pytest.mark.asyncio
 async def test_handle_edit_result_schedules_update(run_worker_mock: Mock, app):
     async with app.run_test():
+        # GIVEN
         widget = WorkItemInfoContainer()
         await app.screen.mount(widget)
         data = {'jira_field_key': 'description', 'content': 'updated text'}
+        # WHEN
         widget._handle_edit_result(data)
-        run_worker_mock.assert_called_once_with(widget._update_field(data))
+        # THEN
+        run_worker_mock.assert_called()
+        assert run_worker_mock.call_count == 3
 
 
+@pytest.mark.parametrize('handle_edit_result_argument', [{}, {'content': 'updated text'}])
 @patch.object(WorkItemInfoContainer, 'run_worker')
 @pytest.mark.asyncio
-async def test_handle_edit_result_without_field_key_shows_error(run_worker_mock: Mock, app):
+async def test_handle_edit_result_without_expected_data_shows_error(
+    run_worker_mock: Mock, handle_edit_result_argument, app
+):
     async with app.run_test():
+        # GIVEN
         widget = WorkItemInfoContainer()
         await app.screen.mount(widget)
-        widget._handle_edit_result({'content': 'updated text'})
-        run_worker_mock.assert_not_called()
+        # WHEN
+        widget._handle_edit_result(handle_edit_result_argument)
+        # THEN
+        run_worker_mock.assert_called()
+        assert run_worker_mock.call_count == 2
 
 
 @patch.object(WorkItemInfoContainer, '_send_work_item_updated_message')

--- a/uv.lock
+++ b/uv.lock
@@ -771,7 +771,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.4.2,<9.0.0" },
     { name = "gitpython", specifier = ">=3.1.47,<3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "marklas", specifier = "==0.8.1" },
+    { name = "marklas", specifier = "==0.8.2" },
     { name = "puremagic", specifier = ">=2.2.0,<3.0.0" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.14.2,<3.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
@@ -901,14 +901,14 @@ linkify = [
 
 [[package]]
 name = "marklas"
-version = "0.8.1"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mistune" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/bf/52fcd6f3c830003e69ef88675285006afd20f38000091da29a5c05348cc4/marklas-0.8.1.tar.gz", hash = "sha256:42eae648e291b9117008b97c2d43c9e4efba15bca85b63b9433e977308f3b719", size = 48148, upload-time = "2026-06-23T02:50:15.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/92/b2352fa3fe9810d59dd747a713b05a3841d64cc4a256ae6dc5f9cadde7ee/marklas-0.8.2.tar.gz", hash = "sha256:1d6baa8688ea1bb56d1c9e0eac19979a78d496d408814dffb1b90a318334eec2", size = 48209, upload-time = "2026-06-30T07:20:59.399Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/89/37b11718a56b6ec07cda663e6b7cf10a4005666ee6ef369e25f4173054d8/marklas-0.8.1-py3-none-any.whl", hash = "sha256:ab85f3d15d7371f77904bacfd5173cd713e723ab5394e11510c68e59dbc8a68a", size = 56523, upload-time = "2026-06-23T02:50:14.392Z" },
+    { url = "https://files.pythonhosted.org/packages/af/47/79b835c0e08982fb0a2f808ab7406617e40206f636b630f0277248790e3f/marklas-0.8.2-py3-none-any.whl", hash = "sha256:bd0bf739d784b40e83ca9ef2e3502b2915b1faa4125ff7173f19bc2fddff799a", size = 56592, upload-time = "2026-06-30T07:20:58.147Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR:

- fixes tests added in https://github.com/whyisdifficult/jiratui/pull/281/
- defines `EmptyTextAreaStaticWidget` and uses it in the Info tab
- bumps `marklas` to `0.8.2`