### PR TITLE
JT-56: allow users to specify the status of a work item when creating new items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This feature uses the Jira Software Cloud REST API. By [@whyisdifficult](https:/
 - Implement a client for the Jira Software Cloud REST API. The application can use this API to retrieve the sprints of a
 project. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/293
 - Add config variable `enable_logging` to enable/disable logging. The default is `False`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/294
-- Add support for specifying the status of a work item being created. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+- Add support for specifying the status of a work item being created. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/295
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This feature uses the Jira Software Cloud REST API. By [@whyisdifficult](https:/
 - Implement a client for the Jira Software Cloud REST API. The application can use this API to retrieve the sprints of a
 project. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/293
 - Add config variable `enable_logging` to enable/disable logging. The default is `False`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/294
+- Add support for specifying the status of a work item being created. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
 
 ### Bug Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test:
 
 .PHONY: coverage
 coverage:
-	pytest --cov=src/jiratui --cov-report=term-missing src/jiratui/
+	pytest --cov=src/jiratui --cov-report term-missing:skip-covered src/jiratui/
 
 .PHONY: docs-live
 docs-live:

--- a/src/jiratui/api_controller/controller.py
+++ b/src/jiratui/api_controller/controller.py
@@ -1896,7 +1896,7 @@ class APIController:
             )
         # extract the ID of the transition that corresponds to the selected status ID
         transition_id: str | None = None
-        for transition in response.result:
+        for transition in response.result or []:
             if transition.to_state.id == status_id:
                 transition_id = transition.id
                 break
@@ -2303,8 +2303,8 @@ class APIController:
         fields: dict[str, Any] = {}
 
         # fetch create metadata to check which fields are available for this project/issue type
-        project_key = data.get('project_key')
-        issue_type_id = data.get('issue_type_id')
+        project_key = data.get('project_key', '')
+        issue_type_id = data.get('issue_type_id', '')
         available_fields: set[str] = set()
 
         if project_key and issue_type_id:

--- a/src/jiratui/css/jt.tcss
+++ b/src/jiratui/css/jt.tcss
@@ -688,7 +688,10 @@ WorkItemTypeSelectionField {
 
 .create-work-item-generic-selector {
     border: round $primary-lighten-3;
+    width: 100%;
+    margin: 0 0;
     padding: 0 1;
+    background: $background;
     &.required {
         border: round $accent;
     }

--- a/src/jiratui/tests/test_main_screen.py
+++ b/src/jiratui/tests/test_main_screen.py
@@ -911,9 +911,9 @@ async def test_show_quick_view_screen_after_creating_work_item_view_work_item_af
         result=JiraBaseIssue(id='2', key='key-2')
     )
     async with app.run_test() as pilot:
-        cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
         # WHEN
-        await app.screen.create_work_item({'summary': 'some value here'})
+        await screen.create_work_item({'summary': 'some value here'})
         await pilot.pause()
         # THEN
         assert isinstance(app.screen, WorkItemQuickViewScreen)
@@ -949,6 +949,104 @@ async def test_create_work_item_with_recent_history_enabled(
         add_item_to_recent_history_mock.assert_called_once_with('key-2', '', '', '')
 
 
+@patch.object(APIController, 'transition_issue_status')
+@patch.object(APIController, 'create_work_item')
+@patch('jiratui.widgets.screen.MainScreen.fetch_statuses')
+@patch('jiratui.widgets.screen.MainScreen.fetch_issue_types')
+@patch('jiratui.widgets.screen.MainScreen.fetch_projects')
+@pytest.mark.asyncio
+async def test_create_work_item_with_status_transition(
+    fetch_projects_mock: AsyncMock,
+    fetch_issue_types_mock: AsyncMock,
+    fetch_statuses_mock: AsyncMock,
+    create_work_item_mock: AsyncMock,
+    transition_issue_status_mock: AsyncMock,
+    app,
+):
+    """Creating a work item when the status field is set will request the API to transition the status of the recently
+    created work item."""
+    # GIVEN
+    app.config.view_work_item_after_creation = False
+    app.config.enable_recent_history = False
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='2', key='key-2')
+    )
+    async with app.run_test() as pilot:
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await screen.create_work_item({'summary': 'some value here', 'status': '1'})
+        await pilot.pause()
+        # THEN
+        transition_issue_status_mock.assert_called_once_with('key-2', '1')
+
+
+@patch.object(APIController, 'transition_issue_status')
+@patch.object(APIController, 'create_work_item')
+@patch('jiratui.widgets.screen.MainScreen.fetch_statuses')
+@patch('jiratui.widgets.screen.MainScreen.fetch_issue_types')
+@patch('jiratui.widgets.screen.MainScreen.fetch_projects')
+@pytest.mark.asyncio
+async def test_create_work_item_without_status_transition(
+    fetch_projects_mock: AsyncMock,
+    fetch_issue_types_mock: AsyncMock,
+    fetch_statuses_mock: AsyncMock,
+    create_work_item_mock: AsyncMock,
+    transition_issue_status_mock: AsyncMock,
+    app,
+):
+    """Creating a work item when the status field is not set will not request the API to transition the status of the
+    recently created work item."""
+    # GIVEN
+    app.config.view_work_item_after_creation = False
+    app.config.enable_recent_history = False
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='2', key='key-2')
+    )
+    async with app.run_test() as pilot:
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await screen.create_work_item({'summary': 'some value here'})
+        await pilot.pause()
+        # THEN
+        transition_issue_status_mock.assert_not_called()
+
+
+@patch('jiratui.widgets.screen.MainScreen._add_item_to_recent_history')
+@patch('jiratui.widgets.screen.MainScreen._open_quick_view_screen')
+@patch.object(APIController, 'transition_issue_status')
+@patch.object(APIController, 'create_work_item')
+@patch('jiratui.widgets.screen.MainScreen.fetch_statuses')
+@patch('jiratui.widgets.screen.MainScreen.fetch_issue_types')
+@patch('jiratui.widgets.screen.MainScreen.fetch_projects')
+@pytest.mark.asyncio
+async def test_create_work_item_fails_to_create_item(
+    fetch_projects_mock: AsyncMock,
+    fetch_issue_types_mock: AsyncMock,
+    fetch_statuses_mock: AsyncMock,
+    create_work_item_mock: AsyncMock,
+    transition_issue_status_mock: AsyncMock,
+    open_quick_view_screen_mock: AsyncMock,
+    add_item_to_recent_history_mock: Mock,
+    app,
+):
+    """When the API fails to create the work item then the work item's status is not transitioned and the app does not
+    open the quick view and does not update the recent history."""
+    # GIVEN
+    app.config.view_work_item_after_creation = True
+    app.config.enable_recent_history = True
+    create_work_item_mock.return_value = APIControllerResponse(success=False, result=None)
+    async with app.run_test() as pilot:
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await screen.create_work_item({'summary': 'some value here', 'status': '1'})
+        await pilot.pause()
+        # THEN
+        transition_issue_status_mock.assert_not_called()
+        open_quick_view_screen_mock.assert_not_called()
+        add_item_to_recent_history_mock.assert_not_called()
+        assert not screen.loading_container.display
+
+
 @patch('jiratui.widgets.screen.MainScreen._add_item_to_recent_history')
 @patch.object(APIController, 'create_work_item')
 @patch('jiratui.widgets.screen.MainScreen.fetch_statuses')
@@ -970,9 +1068,9 @@ async def test_create_work_item_with_recent_history_disabled(
         result=JiraBaseIssue(id='2', key='key-2')
     )
     async with app.run_test() as pilot:
-        cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
         # WHEN
-        await app.screen.create_work_item({'summary': 'some value here'})
+        await screen.create_work_item({'summary': 'some value here'})
         await pilot.pause()
         # THEN
         add_item_to_recent_history_mock.assert_not_called()
@@ -996,9 +1094,9 @@ async def test_show_quick_view_screen_after_creating_work_item_view_work_item_af
         result=JiraBaseIssue(id='2', key='key-2')
     )
     async with app.run_test() as pilot:
-        cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
         # WHEN
-        await app.screen.create_work_item({'summary': 'some value here'})
+        await screen.create_work_item({'summary': 'some value here'})
         await pilot.pause()
         # THEN
         assert isinstance(app.screen, MainScreen)
@@ -1025,9 +1123,9 @@ async def test_show_quick_view_screen_after_creating_work_dismiss_with_search(
         result=JiraBaseIssue(id='2', key='key-2')
     )
     async with app.run_test() as pilot:
-        cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
         # WHEN
-        await app.screen.create_work_item({'summary': 'some value here'})
+        await screen.create_work_item({'summary': 'some value here'})
         await pilot.pause()
         assert isinstance(app.screen, WorkItemQuickViewScreen)
         await pilot.press('ctrl+r')  # hit search to dismiss and search
@@ -1072,9 +1170,9 @@ async def test_show_quick_view_screen_after_creating_work_dismiss_with_row_selec
         result=JiraIssueSearchResponse(issues=[jira_issues[1]])
     )
     async with app.run_test() as pilot:
-        cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
         # WHEN
-        await app.screen.create_work_item({'summary': 'some value here'})
+        await screen.create_work_item({'summary': 'some value here'})
         await pilot.pause()
         assert isinstance(app.screen, WorkItemQuickViewScreen)
         await pilot.press('tab')
@@ -1120,9 +1218,9 @@ async def test_show_quick_view_screen_after_creating_work_dismiss_with_row_selec
         result=JiraIssueSearchResponse(issues=[jira_issues[1]])
     )
     async with app.run_test() as pilot:
-        cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
         # WHEN
-        await app.screen.create_work_item({'summary': 'some value here'})
+        await screen.create_work_item({'summary': 'some value here'})
         await pilot.pause()
         assert isinstance(app.screen, WorkItemQuickViewScreen)
         await pilot.press('tab')
@@ -1154,9 +1252,9 @@ async def test_show_quick_view_screen_after_creating_work_dismiss_with_escape(
         result=JiraBaseIssue(id='2', key='key-2')
     )
     async with app.run_test() as pilot:
-        cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
         # WHEN
-        await app.screen.create_work_item({'summary': 'some value here'})
+        await screen.create_work_item({'summary': 'some value here'})
         await pilot.pause()
         assert isinstance(app.screen, WorkItemQuickViewScreen)
         await pilot.press('escape')  # dismiss with escape does not trigger search

--- a/src/jiratui/widgets/commons/base.py
+++ b/src/jiratui/widgets/commons/base.py
@@ -332,7 +332,7 @@ class ProjectSelectionWidget(Select, BaseFieldWidget, BaseUpdateFieldWidget):
             allow_blank=True,
         )
 
-        # Setup base field properties
+        # setup base field properties
         self.setup_base_field(
             mode=mode,
             field_id=field_id,
@@ -342,7 +342,7 @@ class ProjectSelectionWidget(Select, BaseFieldWidget, BaseUpdateFieldWidget):
             compact=True,
         )
 
-        # Mode-specific setup
+        # mode-specific setup
         if mode == FieldMode.UPDATE:
             self.setup_update_field(
                 jira_field_key=jira_field_key,
@@ -352,7 +352,7 @@ class ProjectSelectionWidget(Select, BaseFieldWidget, BaseUpdateFieldWidget):
             self.add_class('create-update-field-widget')
         else:
             # CREATE mode specific setup
-            self.add_class('create-work-item-project-selector')
+            self.add_class('create-work-item-generic-selector')
 
     def watch_projects(self, projects: dict | None = None) -> None:
         """Watches for changes to the projects reactive property (CREATE mode).

--- a/src/jiratui/widgets/create_work_item/factory.py
+++ b/src/jiratui/widgets/create_work_item/factory.py
@@ -41,7 +41,7 @@ def create_widgets_for_work_item_creation(
     api_controller: APIController | None = None,
     adf_support_enabled: bool = True,
 ) -> list[Widget]:
-    """Creates a list of Textual widgets for the "form" that allows users to create work items.
+    """Creates a list of widgets for the "form" that allows users to create work items.
 
     Fields that are statically included in the form, such as `project`, `issuetype`, `reporter`, etc. are ignored by
     this function. As a result this function will not return Textual's Widget instances for them. These fields are

--- a/src/jiratui/widgets/create_work_item/fields.py
+++ b/src/jiratui/widgets/create_work_item/fields.py
@@ -1,9 +1,10 @@
-"""these widgets are used by the screen that allows users to create new work items."""
+"""These widgets are used by the screen that allows users to create new work items."""
 
 from textual import on
 from textual.widgets import Input
 
 from jiratui.widgets.commons.base import FieldMode, IssueTypeSelectionWidget, ProjectSelectionWidget
+from jiratui.widgets.filters import IssueStatusSelectionInput
 
 
 class WorkItemProjectSelectionField(ProjectSelectionWidget):
@@ -77,3 +78,16 @@ class ParentKeyField(Input):
     def clean_value(self, event: Input.Blurred) -> None:
         if event.value is not None:
             self.value = event.value.strip().replace(' ', '')
+
+
+class WorkItemStatusField(IssueStatusSelectionInput):
+    """A [IssueStatusSelectionInput](#jiratui.widgets.filters.IssueStatusSelectionInput) widget to pick the status of
+    the work item being created."""
+
+    WIDGET_ID = 'jira-issue-status-selector-create'
+
+    def __init__(self, statuses: list):
+        super().__init__(statuses, classes='create-work-item-generic-selector')
+        self.jira_field_key = 'status'
+        """The key to used by Jira to identify this field in the edit-metadata."""
+        self.border_subtitle = None

--- a/src/jiratui/widgets/create_work_item/screen.py
+++ b/src/jiratui/widgets/create_work_item/screen.py
@@ -52,6 +52,7 @@ from jiratui.widgets.create_work_item.fields import (
     ParentKeyField,
     SummaryField,
     WorkItemProjectSelectionField,
+    WorkItemStatusField,
     WorkItemTypeSelectionField,
 )
 
@@ -176,7 +177,6 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
     This screen does not actually create the work item. Instead, upon dismissing the screen the caller will receive the
     necessary data to create the work item via the Jira API.
     ```
-
     **See Also**:
     - [Create Work Item Screen Design](#components-create-work-item-screen)
     - [Use Case: Create Work Item](#use-case-create-work-item)
@@ -255,6 +255,10 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
     @property
     def assignee_selector(self) -> JiraUserInput:
         return self.query_one('#create-work-item-assignee-selector', expect_type=JiraUserInput)
+
+    @property
+    def status_selector(self) -> WorkItemStatusField:
+        return self.query_one(WorkItemStatusField)
 
     @property
     def assignee_autocomplete(self) -> UsersAutoComplete:
@@ -342,6 +346,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                         ).add_class(*['create-update-users-field-widget'])
                         yield SummaryField()
                         yield ParentKeyField(self._parent_work_item_key)
+                        yield WorkItemStatusField([])
                     # dynamically-created widgets
                     with VerticalScroll(classes='add-work-item-form-textarea-fields'):
                         with TextAreaTabbedContent(
@@ -415,7 +420,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
         return self.__configuration.enable_advanced_full_text_search
 
     async def _search_work_items(self, query: str) -> list[JiraIssue] | None:
-        """Search and retrieve work items to fill in the autocomplete suggestions for parent key.
+        """Searches and retrieves work items to fill in the autocomplete suggestions for parent key.
 
         See Also: https://support.atlassian.com/jira-software-cloud/docs/jql-fields/
 
@@ -490,8 +495,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
             if response.success:
                 types = response.result or []
             types.sort(key=lambda x: x.name)
-            options = [(t.name, t.id) for t in types]
-            self.issue_type_selector.set_options(options)
+            self.issue_type_selector.set_options([(t.name, t.id) for t in types])
 
     @on(Select.Changed, 'WorkItemProjectSelectionField')
     def handle_project_selection(self) -> None:
@@ -499,7 +503,7 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
 
         This also:
         - updates the status of the "Save" button.
-        - removes all the panes used for displaying textarea-based field widgets.
+        - removes all the panes used for displaying non-textarea field widgets.
         - if the user selected a project then it retrieves the project's active and future sprints and stores them in
         the application's session.
 
@@ -507,29 +511,35 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
             None
         """
 
+        # clear the (non-textarea) dynamic widgets
+        self.additional_fields.remove_children()
         self.run_worker(self.fetch_available_issue_types(self.project_selector.selection))
         if self.project_selector.selection:
             self.run_worker(self._fetch_sprints_in_project(self.project_selector.selection))
-        # clean up the panes that contain textarea-based widgets
-        self.additional_fields.remove_children()
         self.save_button.disabled = not self._validate_required_fields()
 
     @on(Select.Changed, 'WorkItemTypeSelectionField')
     def handle_issue_type_selection(self) -> None:
         """Fetches metadata for creating issues in the selected project and of the selected type.
 
-        This also updates the status of the "Save" button.
+        This also retrieves the applicable status codes and updates the status of the "Save" button.
 
         Returns:
             None
         """
 
-        if self.project_selector.selection and self.issue_type_selector.selection:
-            self.run_worker(
-                self.fetch_issue_create_metadata(
-                    self.project_selector.selection, self.issue_type_selector.selection
-                ),
+        # clear the (non-textarea) dynamic widgets
+        self.additional_fields.remove_children()
+        self.run_worker(
+            self._fetch_issue_create_metadata(
+                self.project_selector.selection, self.issue_type_selector.selection
             )
+        )
+        self.run_worker(
+            self._retrieve_applicable_status_codes(
+                self.project_selector.selection, self.issue_type_selector.selection
+            )
+        )
         self.save_button.disabled = not self._validate_required_fields()
 
     @on(Select.Changed, '#create-work-item-reporter-selector')
@@ -550,7 +560,9 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
 
         self.save_button.disabled = not self._validate_required_fields()
 
-    async def fetch_issue_create_metadata(self, project_key: str, issue_type_id: str) -> None:
+    async def _fetch_issue_create_metadata(
+        self, project_key: str | None = None, issue_type_id: str | None = None
+    ) -> None:
         """Fetches the metadata for creating work items of a given type in the given project.
 
         This function does a few things:
@@ -558,110 +570,131 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
         - Builds and mounts the necessary widgets that compose the create-work-item form.
 
         Args:
-            project_key: the key of the project for which we want to create a work item.
-            issue_type_id: the type of work item we want to create.
+            project_key: the key of the project selected by the user.
+            issue_type_id: the ID of the type of work item selected by the user.
 
         Returns:
             None
         """
 
-        await self.additional_fields.remove_children()
-        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
-        response: APIControllerResponse = await application.api.get_issue_create_metadata(
-            project_key, issue_type_id
-        )
-        work_item_create_metadata: dict | None = response.result
-        if not response.success or not work_item_create_metadata:
-            self.notify(
-                'Unable to find the required information for creating a work item.',
-                title='Missing Required Metadata',
-                severity='error',
+        if project_key and issue_type_id:
+            application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
+            response: APIControllerResponse = await application.api.get_issue_create_metadata(
+                project_key, issue_type_id
             )
-        else:
-            # store fields metadata for proper value formatting later
-            fields_data: list[dict[str, Any]] = work_item_create_metadata.get('fields', [])
+            work_item_create_metadata: dict | None = response.result
+            if not response.success or not work_item_create_metadata:
+                self.notify(
+                    'Unable to find the required information for creating a work item.',
+                    title='Missing Required Metadata',
+                    severity='error',
+                )
+            else:
+                # store fields metadata for proper value formatting later
+                fields_data: list[dict[str, Any]] = work_item_create_metadata.get('fields', [])
 
-            for field in fields_data:
-                if field_id := field.get('fieldId', ''):
-                    self._field_metadata[field_id] = field
+                for field in fields_data:
+                    if field_id := field.get('fieldId', ''):
+                        self._field_metadata[field_id] = field
 
-                # check if description is required and update the widget
-                if field_id == 'description' and field.get('required', False):
-                    self.description_field.mark_required()
+                    # check if description is required and update the widget
+                    if field_id == 'description' and field.get('required', False):
+                        self.description_field.mark_required()
 
-                # check if reporter field is editable
-                if field_id == 'reporter':
-                    operations = field.get('operations', [])
-                    self._reporter_is_editable = 'set' in operations
-                    # hide reporter field if not editable
-                    self.reporter_selector.display = self._reporter_is_editable
+                    # check if reporter field is editable
+                    if field_id == 'reporter':
+                        operations = field.get('operations', [])
+                        self._reporter_is_editable = 'set' in operations
+                        # hide reporter field if not editable
+                        self.reporter_selector.display = self._reporter_is_editable
 
-            # create all the widgets for the additional fields supported
-            widgets_to_create_work_item: list[Widget] = create_widgets_for_work_item_creation(
-                data=fields_data,
-                api_controller=application.api,
-                adf_support_enabled=self.adf_support_enabled,
-            )
-
-            # split the fields based on type so we can mount them in different places in the UI
-            textarea_widgets: list[ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget] = []
-            non_textarea_widgets: list[Widget] = []
-            sprint_selection_widgets: list[SprintSelectionWidget] = []
-            for widget in widgets_to_create_work_item:
-                if isinstance(widget, ADFMarkdownTextAreaWidget) or isinstance(
-                    widget, PlainTextTextAreaWidget
-                ):
-                    textarea_widgets.append(widget)
-                elif isinstance(widget, SprintSelectionWidget):
-                    sprint_selection_widgets.append(widget)
-                    non_textarea_widgets.append(widget)
-                else:
-                    non_textarea_widgets.append(widget)
-
-            # mount the (non-textarea) widgets on the left column
-            await self.additional_fields.mount_all(non_textarea_widgets)
-            # mount the widgets on the right column but before make sure we remove all the panes except the
-            # statically-defined pane that contains the description widget
-            await self._remove_textarea_panes()
-            for textarea_widget in textarea_widgets:
-                await self.textarea_fields_tabbed_content.add_pane(
-                    TextAreaTabPane(textarea_widget.border_title, textarea_widget)
+                # create all the widgets for the additional fields supported
+                widgets_to_create_work_item: list[Widget] = create_widgets_for_work_item_creation(
+                    data=fields_data,
+                    api_controller=application.api,
+                    adf_support_enabled=self.adf_support_enabled,
                 )
 
-            # create and mount AutoComplete widgets for labels inputs and custom fields that support multiple users
-            for input_widget in self.additional_fields.query(Input):
-                if isinstance(input_widget, LabelsWidget):
-                    # set up the autocomplete widget for the field that allows users to select labels
-                    field_meta = self._field_metadata.get('labels', {})
-                    required = field_meta.get('required', False)
-                    title = field_meta.get('name', 'Labels')
-                    await self.additional_fields.mount(
-                        LabelsAutoComplete(
-                            target=input_widget,
-                            api_controller=application.api,
-                            required=required,
-                            title=title,
-                        )
-                    )
-                elif isinstance(input_widget, MultiUserPickerWidget):
-                    await self.additional_fields.mount(
-                        MultiUserPickerAutoComplete(
-                            target=input_widget, api_controller=application.api
-                        )
-                    )
-                elif isinstance(input_widget, SingleUserPickerWidget):
-                    await self.additional_fields.mount(
-                        UsersAutoComplete(target=input_widget, api_controller=application.api)
+                # split the fields based on type so we can mount them in different places in the UI
+                textarea_widgets: list[ADFMarkdownTextAreaWidget | PlainTextTextAreaWidget] = []
+                non_textarea_widgets: list[Widget] = []
+                sprint_selection_widgets: list[SprintSelectionWidget] = []
+                for widget in widgets_to_create_work_item:
+                    if isinstance(widget, ADFMarkdownTextAreaWidget) or isinstance(
+                        widget, PlainTextTextAreaWidget
+                    ):
+                        textarea_widgets.append(widget)
+                    elif isinstance(widget, SprintSelectionWidget):
+                        sprint_selection_widgets.append(widget)
+                        non_textarea_widgets.append(widget)
+                    else:
+                        non_textarea_widgets.append(widget)
+
+                # mount the (non-textarea) widgets on the left column
+                await self.additional_fields.mount_all(non_textarea_widgets)
+                # mount the widgets on the right column but before make sure we remove all the panes except the
+                # statically-defined pane that contains the description widget
+                await self._remove_textarea_panes()
+                for textarea_widget in textarea_widgets:
+                    await self.textarea_fields_tabbed_content.add_pane(
+                        TextAreaTabPane(textarea_widget.border_title, textarea_widget)
                     )
 
-            # populate the sprint selection widget(s) with the options
-            if sprint_selection_widgets and self.project_selector.selection:
-                if sprints := await self._get_sprints_in_project(self.project_selector.selection):
-                    for sprint_widget in sprint_selection_widgets:
-                        sprint_widget.set_options(sprints)
+                # create and mount AutoComplete widgets for labels inputs and custom fields that support multiple users
+                for input_widget in self.additional_fields.query(Input):
+                    if isinstance(input_widget, LabelsWidget):
+                        # set up the autocomplete widget for the field that allows users to select labels
+                        field_meta = self._field_metadata.get('labels', {})
+                        required = field_meta.get('required', False)
+                        title = field_meta.get('name', 'Labels')
+                        await self.additional_fields.mount(
+                            LabelsAutoComplete(
+                                target=input_widget,
+                                api_controller=application.api,
+                                required=required,
+                                title=title,
+                            )
+                        )
+                    elif isinstance(input_widget, MultiUserPickerWidget):
+                        await self.additional_fields.mount(
+                            MultiUserPickerAutoComplete(
+                                target=input_widget, api_controller=application.api
+                            )
+                        )
+                    elif isinstance(input_widget, SingleUserPickerWidget):
+                        await self.additional_fields.mount(
+                            UsersAutoComplete(target=input_widget, api_controller=application.api)
+                        )
+
+                # populate the sprint selection widget(s) with the options
+                if sprint_selection_widgets and project_key:
+                    if sprints := await self._get_sprints_in_project(project_key):
+                        for sprint_widget in sprint_selection_widgets:
+                            sprint_widget.set_options(sprints)
+
+    async def _retrieve_applicable_status_codes(
+        self, project_key: str | None = None, issue_type_id: str | None = None
+    ) -> None:
+        work_status_codes_options: list[tuple[str, str]] = []
+        if project_key and issue_type_id:
+            application = cast('JiraApp', self.app)  # type: ignore[name-defined] # noqa: F821
+            response: APIControllerResponse = await application.api.get_project_statuses(
+                project_key
+            )
+            status_codes_by_work_item_type_id: dict | None
+            if response.success and (status_codes_by_work_item_type_id := response.result):
+                record: dict = status_codes_by_work_item_type_id.get(issue_type_id, {})
+                work_status_codes_options = sorted(
+                    [
+                        (status.name, str(status.id))
+                        for status in record.get('issue_type_statuses', [])
+                    ],
+                    key=lambda x: x[0],
+                )
+        self.status_selector.set_options(work_status_codes_options)
 
     async def _fetch_sprints_in_project(self, key: str | None = None) -> None:
-        """Fetches the sprints of a project and update the data in the application's session.
+        """Fetches the sprints of a project and updates the data in the application's session.
 
         This function attempts to get the data from the application's session to avoid making unnecessary API
         requests. If the session does not have the data then it fetches the sprints from the API and updates the
@@ -752,7 +785,6 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
 
         if custom_type == CustomFieldType.USER_PICKER.value:
             return {'accountId': value}
-
         elif custom_type == CustomFieldType.FLOAT.value or schema.get('type') == 'number':
             if value:  # Type-safe check to prevent ~AlwaysFalsy error
                 try:
@@ -760,7 +792,6 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                 except (ValueError, TypeError):
                     # invalid float - skip this field
                     return None
-            return None
 
         # labels field (array of strings)
         elif field_id == 'labels' or (
@@ -812,13 +843,25 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
             )
         else:
             # process widgets that are created statically
-            data: dict[str, Any] = {
-                self.project_selector.jira_field_key: self.project_selector.selection,
-                self.parent_key_field.jira_field_key: self.parent_key_field.value,
-                self.issue_type_selector.jira_field_key: self.issue_type_selector.selection,
-                self.assignee_selector.jira_field_key: self.assignee_selector.account_id,
-                self.summary_field.jira_field_key: self.summary_field.value,
-            }
+            data: dict[str, Any] = {}
+
+            if self.project_selector.selection:
+                data[self.project_selector.jira_field_key] = self.project_selector.selection
+
+            if self.parent_key_field.value:
+                data[self.parent_key_field.jira_field_key] = self.parent_key_field.value
+
+            if self.issue_type_selector.selection:
+                data[self.issue_type_selector.jira_field_key] = self.issue_type_selector.selection
+
+            if self.assignee_selector.account_id:
+                data[self.assignee_selector.jira_field_key] = self.assignee_selector.account_id
+
+            if self.summary_field.value:
+                data[self.summary_field.jira_field_key] = self.summary_field.value
+
+            if self.status_selector.selection:
+                data[self.status_selector.jira_field_key] = self.status_selector.selection
 
             if self.description_field.value_is_empty:
                 data[self.description_field.jira_field_key] = None

--- a/src/jiratui/widgets/create_work_item/tests/test_create_work_item.py
+++ b/src/jiratui/widgets/create_work_item/tests/test_create_work_item.py
@@ -10,6 +10,7 @@ from jiratui.config import ApplicationConfiguration
 from jiratui.models import (
     AgileSprint,
     AgileSprintState,
+    IssueStatus,
     IssueType,
     JiraIssueSearchResponse,
     Project,
@@ -37,7 +38,7 @@ from jiratui.widgets.create_work_item.fields import (
     WorkItemProjectSelectionField,
     WorkItemTypeSelectionField,
 )
-from jiratui.widgets.create_work_item.screen import AddWorkItemScreen
+from jiratui.widgets.create_work_item.screen import AddWorkItemScreen, TextAreaTabbedContent
 
 
 @pytest.fixture
@@ -58,7 +59,7 @@ def create_metadata_with_editable_reporter() -> dict:
             {
                 'fieldId': 'description',
                 'name': 'Description',
-                'required': False,
+                'required': True,
                 'operations': ['set'],
             },
             {
@@ -471,7 +472,7 @@ async def test_reporter_field_hidden_when_not_editable(
         await pilot.pause()
 
         # Trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('TEST', 'task-123')
         await pilot.pause()
 
         # Assertions
@@ -496,7 +497,7 @@ async def test_reporter_field_shown_when_editable(
         await pilot.pause()
 
         # Trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('TEST', 'task-123')
         await pilot.pause()
 
         # Assertions
@@ -521,7 +522,7 @@ async def test_validation_skips_reporter_when_not_editable(
         await pilot.pause()
 
         # Trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('TEST', 'task-123')
         await pilot.pause()
 
         # Mock the selection properties to return valid values
@@ -567,7 +568,7 @@ async def test_save_excludes_reporter_when_not_editable(
         await pilot.pause()
 
         # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('TEST', 'task-123')
         await pilot.pause()
 
         # Mock dismiss
@@ -596,6 +597,9 @@ async def test_save_excludes_reporter_when_not_editable(
             patch.object(
                 type(screen.description_field), 'text', new_callable=PropertyMock
             ) as mock_description,
+            patch.object(
+                type(screen.status_selector), 'selection', new_callable=PropertyMock
+            ) as mock_status,
         ):
             mock_project.return_value = 'TEST'
             mock_issue_type.return_value = 'task-123'
@@ -604,6 +608,7 @@ async def test_save_excludes_reporter_when_not_editable(
             mock_parent.return_value = None
             mock_summary.return_value = 'Test Summary'
             mock_description.return_value = 'Test Description'
+            mock_status.return_value = '1'
 
             # Trigger save
             screen.handle_save()
@@ -617,6 +622,7 @@ async def test_save_excludes_reporter_when_not_editable(
         )
         assert dismiss_args['project_key'] == 'TEST'
         assert dismiss_args['summary'] == 'Test Summary'
+        assert dismiss_args['status'] == '1'
 
 
 @patch.object(AddWorkItemScreen, 'adf_support_enabled', PropertyMock(return_value=True))
@@ -638,7 +644,7 @@ async def test_save_includes_reporter_when_editable(
         await pilot.pause()
 
         # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('TEST', 'task-123')
         await pilot.pause()
 
         # Mock dismiss
@@ -697,80 +703,41 @@ async def test_save_includes_reporter_when_editable(
         }
 
 
+@patch.object(AddWorkItemScreen, '_validate_required_fields')
 @patch.object(AddWorkItemScreen, 'adf_support_enabled', PropertyMock(return_value=True))
 @patch.object(APIController, 'get_issue_create_metadata')
 @pytest.mark.asyncio
 async def test_save_includes_additional_fields_with_adf_support_enabled(
-    get_issue_create_metadata_mock: AsyncMock, app, create_metadata_with_editable_reporter
+    get_issue_create_metadata_mock: AsyncMock, validate_required_fields_mock: Mock, app
 ):
     # GIVEN
     app.config.create_additional_fields_ignore_ids = []
     app.config.enable_creating_additional_fields = True
     get_issue_create_metadata_mock.return_value = APIControllerResponse(
-        result=create_metadata_with_editable_reporter
+        result={
+            'fields': [
+                {
+                    'fieldId': 'description',
+                    'name': 'Description',
+                    'required': True,
+                    'operations': ['set'],
+                }
+            ]
+        }
     )
+    validate_required_fields_mock.return_value = True
     async with app.run_test() as pilot:
-        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='reporter123')
+        screen = AddWorkItemScreen(project_key='P1', reporter_account_id='reporter123')
         await app.push_screen(screen)
         await pilot.pause()
-
-        # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('P1', 'task-123')
         await pilot.pause()
-
-        # Mock dismiss
         screen.dismiss = Mock()
-
-        # Mock the selection and value properties
         with (
-            patch.object(
-                type(screen.project_selector), 'selection', new_callable=PropertyMock
-            ) as mock_project,
-            patch.object(
-                type(screen.issue_type_selector), 'selection', new_callable=PropertyMock
-            ) as mock_issue_type,
-            patch.object(type(screen.assignee_selector), 'account_id', new_callable=PropertyMock),
-            patch.object(
-                type(screen.reporter_selector), 'account_id', new_callable=PropertyMock
-            ) as mock_reporter,
-            patch.object(
-                type(screen.parent_key_field), 'value', new_callable=PropertyMock
-            ) as mock_parent,
-            patch.object(
-                type(screen.summary_field), 'value', new_callable=PropertyMock
-            ) as mock_summary,
-            patch.object(MultiSelectWidget, 'get_value_for_create') as mock_components,
-            patch.object(
-                DateInputWidget, 'value', new_callable=PropertyMock(return_value='2026-10-10')
-            ),
-            patch.object(
-                URLWidget, 'value', new_callable=PropertyMock(return_value='http://example.bar')
-            ),
-            patch.object(
-                DateTimeInputWidget,
-                'value',
-                new_callable=PropertyMock(return_value='2026-05-05 12:30'),
-            ),
-            patch.object(
-                LabelsWidget, 'value', new_callable=PropertyMock(return_value='test1, test2')
-            ),
-            patch.object(
-                NumericInputWidget, 'value', new_callable=PropertyMock(return_value='123.45')
-            ),
-            patch.object(SingleUserPickerWidget, 'get_value_for_create') as mock_user_picker,
-            patch.object(MultiUserPickerWidget, 'get_value_for_create') as mock_multi_user_picker,
             patch.object(
                 ADFMarkdownTextAreaWidget, 'get_value_for_create'
             ) as mock_textarea_adf_markdown,
         ):
-            mock_project.return_value = 'TEST'
-            mock_issue_type.return_value = 'task-123'
-            mock_reporter.return_value = 'reporter123'
-            mock_parent.return_value = 'issue-1'
-            mock_summary.return_value = 'Test Summary'
-            mock_components.return_value = [{'id': '10000'}]
-            mock_multi_user_picker.return_value = [{'accountId': '3'}, {'accountId': '4'}]
-            mock_user_picker.return_value = '12345qwerty'
             mock_textarea_adf_markdown.return_value = {
                 'type': 'doc',
                 'version': 1,
@@ -788,23 +755,7 @@ async def test_save_includes_additional_fields_with_adf_support_enabled(
         # THEN
         # get the data passed to dismiss
         dismiss_args = screen.dismiss.call_args[0][0]
-        assert len(dismiss_args.keys()) == 17
-        assert dismiss_args['project_key'] == 'TEST'
-        assert dismiss_args['parent_key'] == 'issue-1'
-        assert dismiss_args['issue_type_id'] == 'task-123'
-        assert dismiss_args['assignee_account_id'] == 'reporter123'
-        assert dismiss_args['summary'] == 'Test Summary'
-        assert dismiss_args['reporter_account_id'] == 'reporter123'
-        assert dismiss_args['components'] == [{'id': '10000'}]
-        assert dismiss_args['duedate'] == '2026-10-10'
-        assert dismiss_args['priority'] == '3'
-        assert dismiss_args['customfield_10015'] == 'http://example.bar'
-        assert dismiss_args['customfield_10098'] == '2026-05-05 12:30'
-        assert set(dismiss_args['labels']) == {'test1', 'test2'}
-        assert dismiss_args['customfield_10097'] == 123.45
-        assert dismiss_args['customfield_10095'] == [{'accountId': '3'}, {'accountId': '4'}]
-        assert dismiss_args['customfield_10096'] == '12345qwerty'
-        assert dismiss_args['customfield_10147'] == {
+        assert dismiss_args['description'] == {
             'type': 'doc',
             'version': 1,
             'content': [
@@ -816,389 +767,235 @@ async def test_save_includes_additional_fields_with_adf_support_enabled(
         }
 
 
+@patch('jiratui.widgets.create_work_item.factory._uses_cloud_api')
+@patch.object(AddWorkItemScreen, '_validate_required_fields')
+@patch.object(AddWorkItemScreen, '_get_sprints_in_project')
 @patch.object(AddWorkItemScreen, 'adf_support_enabled', PropertyMock(return_value=True))
 @patch.object(APIController, 'get_issue_create_metadata')
 @pytest.mark.asyncio
 async def test_save_with_support_for_sprint_selection_sprint_selected(
     get_issue_create_metadata_mock: AsyncMock,
+    get_sprints_in_project_mock: AsyncMock,
+    validate_required_fields_mock: Mock,
+    uses_cloud_api_mock: Mock,
     app,
-    create_metadata_with_editable_reporter: dict,
 ):
     # GIVEN
     app.config.create_additional_fields_ignore_ids = []
     app.config.enable_creating_additional_fields = True
     get_issue_create_metadata_mock.return_value = APIControllerResponse(
-        result=create_metadata_with_editable_reporter
+        result={
+            'fields': [
+                {
+                    'required': True,
+                    'schema': {
+                        'type': 'array',
+                        'items': 'json',
+                        'custom': 'com.pyxis.greenhopper.jira:gh-sprint',
+                        'customId': 10020,
+                    },
+                    'name': 'Sprint',
+                    'key': 'customfield_10020',
+                    'hasDefaultValue': False,
+                    'operations': ['set'],
+                    'fieldId': 'customfield_10020',
+                }
+            ]
+        }
     )
+    get_sprints_in_project_mock.return_value = [('1', 'Sprint 1')]
+    validate_required_fields_mock.return_value = True
+    uses_cloud_api_mock.return_value = True
     async with app.run_test() as pilot:
-        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='reporter123')
+        screen = AddWorkItemScreen(project_key='P1', reporter_account_id='reporter123')
         await app.push_screen(screen)
         await pilot.pause()
-
-        # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('P1', 'task-123')
         await pilot.pause()
-
-        # Mock dismiss
         screen.dismiss = Mock()
-
-        # Mock the selection and value properties
         with (
-            patch.object(
-                type(screen.project_selector), 'selection', new_callable=PropertyMock
-            ) as mock_project,
-            patch.object(
-                type(screen.issue_type_selector), 'selection', new_callable=PropertyMock
-            ) as mock_issue_type,
-            patch.object(type(screen.assignee_selector), 'account_id', new_callable=PropertyMock),
-            patch.object(
-                type(screen.reporter_selector), 'account_id', new_callable=PropertyMock
-            ) as mock_reporter,
-            patch.object(
-                type(screen.parent_key_field), 'value', new_callable=PropertyMock
-            ) as mock_parent,
-            patch.object(
-                type(screen.summary_field), 'value', new_callable=PropertyMock
-            ) as mock_summary,
-            patch.object(
-                DateInputWidget, 'value', new_callable=PropertyMock(return_value='2026-10-10')
-            ),
             patch.object(SprintSelectionWidget, 'get_value_for_create') as mock_sprint_selection,
-            patch.object(
-                ADFMarkdownTextAreaWidget, 'get_value_for_create'
-            ) as mock_textarea_adf_markdown,
         ):
-            mock_project.return_value = 'TEST'
-            mock_issue_type.return_value = 'task-123'
-            mock_reporter.return_value = 'reporter123'
-            mock_parent.return_value = 'issue-1'
-            mock_summary.return_value = 'Test Summary'
             mock_sprint_selection.return_value = 101
-            mock_textarea_adf_markdown.return_value = {
-                'type': 'doc',
-                'version': 1,
-                'content': [
-                    {
-                        'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
-                        'type': 'paragraph',
-                    }
-                ],
-            }
             # WHEN
             screen.handle_save()
 
         # THEN
-        # get the data passed to dismiss
         dismiss_args = screen.dismiss.call_args[0][0]
-        assert len(dismiss_args.keys()) == 11
-        assert dismiss_args['project_key'] == 'TEST'
-        assert dismiss_args['parent_key'] == 'issue-1'
-        assert dismiss_args['issue_type_id'] == 'task-123'
-        assert dismiss_args['summary'] == 'Test Summary'
-        assert dismiss_args['reporter_account_id'] == 'reporter123'
-        assert dismiss_args['duedate'] == '2026-10-10'
-        assert dismiss_args['priority'] == '3'
-        assert dismiss_args['customfield_10147'] == {
-            'type': 'doc',
-            'version': 1,
-            'content': [
-                {
-                    'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
-                    'type': 'paragraph',
-                }
-            ],
-        }
         assert dismiss_args['customfield_10020'] == 101
 
 
+@patch('jiratui.widgets.create_work_item.factory._uses_cloud_api')
+@patch.object(AddWorkItemScreen, '_validate_required_fields')
+@patch.object(AddWorkItemScreen, '_get_sprints_in_project')
 @patch.object(AddWorkItemScreen, 'adf_support_enabled', PropertyMock(return_value=True))
 @patch.object(APIController, 'get_issue_create_metadata')
 @pytest.mark.asyncio
 async def test_save_with_support_for_sprint_selection_no_sprint_selected(
     get_issue_create_metadata_mock: AsyncMock,
+    get_sprints_in_project_mock: AsyncMock,
+    validate_required_fields_mock: Mock,
+    uses_cloud_api_mock: Mock,
     app,
-    create_metadata_with_editable_reporter: dict,
 ):
     # GIVEN
     app.config.create_additional_fields_ignore_ids = []
     app.config.enable_creating_additional_fields = True
     get_issue_create_metadata_mock.return_value = APIControllerResponse(
-        result=create_metadata_with_editable_reporter
+        result={
+            'fields': [
+                {
+                    'required': True,
+                    'schema': {
+                        'type': 'array',
+                        'items': 'json',
+                        'custom': 'com.pyxis.greenhopper.jira:gh-sprint',
+                        'customId': 10020,
+                    },
+                    'name': 'Sprint',
+                    'key': 'customfield_10020',
+                    'hasDefaultValue': False,
+                    'operations': ['set'],
+                    'fieldId': 'customfield_10020',
+                }
+            ]
+        }
     )
+    get_sprints_in_project_mock.return_value = [('1', 'Sprint 1')]
+    validate_required_fields_mock.return_value = True
+    uses_cloud_api_mock.return_value = True
     async with app.run_test() as pilot:
-        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='reporter123')
+        screen = AddWorkItemScreen(project_key='P1', reporter_account_id='reporter123')
         await app.push_screen(screen)
         await pilot.pause()
-
-        # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('P1', 'task-123')
         await pilot.pause()
-
-        # Mock dismiss
         screen.dismiss = Mock()
-
-        # Mock the selection and value properties
         with (
-            patch.object(
-                type(screen.project_selector), 'selection', new_callable=PropertyMock
-            ) as mock_project,
-            patch.object(
-                type(screen.issue_type_selector), 'selection', new_callable=PropertyMock
-            ) as mock_issue_type,
-            patch.object(type(screen.assignee_selector), 'account_id', new_callable=PropertyMock),
-            patch.object(
-                type(screen.reporter_selector), 'account_id', new_callable=PropertyMock
-            ) as mock_reporter,
-            patch.object(
-                type(screen.parent_key_field), 'value', new_callable=PropertyMock
-            ) as mock_parent,
-            patch.object(
-                type(screen.summary_field), 'value', new_callable=PropertyMock
-            ) as mock_summary,
-            patch.object(
-                DateInputWidget, 'value', new_callable=PropertyMock(return_value='2026-10-10')
-            ),
             patch.object(SprintSelectionWidget, 'get_value_for_create') as mock_sprint_selection,
-            patch.object(
-                ADFMarkdownTextAreaWidget, 'get_value_for_create'
-            ) as mock_textarea_adf_markdown,
         ):
-            mock_project.return_value = 'TEST'
-            mock_issue_type.return_value = 'task-123'
-            mock_reporter.return_value = 'reporter123'
-            mock_parent.return_value = 'issue-1'
-            mock_summary.return_value = 'Test Summary'
             mock_sprint_selection.return_value = None
-            mock_textarea_adf_markdown.return_value = {
-                'type': 'doc',
-                'version': 1,
-                'content': [
-                    {
-                        'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
-                        'type': 'paragraph',
-                    }
-                ],
-            }
             # WHEN
             screen.handle_save()
 
         # THEN
-        # get the data passed to dismiss
         dismiss_args = screen.dismiss.call_args[0][0]
-        assert len(dismiss_args.keys()) == 10
-        assert dismiss_args['project_key'] == 'TEST'
-        assert dismiss_args['parent_key'] == 'issue-1'
-        assert dismiss_args['issue_type_id'] == 'task-123'
-        assert dismiss_args['summary'] == 'Test Summary'
-        assert dismiss_args['reporter_account_id'] == 'reporter123'
-        assert dismiss_args['duedate'] == '2026-10-10'
-        assert dismiss_args['priority'] == '3'
-        assert dismiss_args['customfield_10147'] == {
-            'type': 'doc',
-            'version': 1,
-            'content': [
-                {
-                    'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
-                    'type': 'paragraph',
-                }
-            ],
-        }
         assert 'customfield_10020' not in dismiss_args
 
 
 @patch('jiratui.widgets.create_work_item.factory._uses_cloud_api')
+@patch.object(AddWorkItemScreen, '_validate_required_fields')
+@patch.object(AddWorkItemScreen, '_get_sprints_in_project')
 @patch.object(AddWorkItemScreen, 'adf_support_enabled', PropertyMock(return_value=True))
 @patch.object(APIController, 'get_issue_create_metadata')
 @pytest.mark.asyncio
 async def test_save_with_support_for_sprint_input_sprint_provided(
     get_issue_create_metadata_mock: AsyncMock,
+    get_sprints_in_project_mock: AsyncMock,
+    validate_required_fields_mock: Mock,
     uses_cloud_api_mock: Mock,
     app,
-    create_metadata_with_editable_reporter: dict,
 ):
     # GIVEN
     app.config.create_additional_fields_ignore_ids = []
     app.config.enable_creating_additional_fields = True
     get_issue_create_metadata_mock.return_value = APIControllerResponse(
-        result=create_metadata_with_editable_reporter
+        result={
+            'fields': [
+                {
+                    'required': True,
+                    'schema': {
+                        'type': 'array',
+                        'items': 'json',
+                        'custom': 'com.pyxis.greenhopper.jira:gh-sprint',
+                        'customId': 10020,
+                    },
+                    'name': 'Sprint',
+                    'key': 'customfield_10020',
+                    'hasDefaultValue': False,
+                    'operations': ['set'],
+                    'fieldId': 'customfield_10020',
+                }
+            ]
+        }
     )
+    get_sprints_in_project_mock.return_value = [('1', 'Sprint 1')]
+    validate_required_fields_mock.return_value = True
     uses_cloud_api_mock.return_value = False
     async with app.run_test() as pilot:
-        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='reporter123')
+        screen = AddWorkItemScreen(project_key='P1', reporter_account_id='reporter123')
         await app.push_screen(screen)
         await pilot.pause()
-
-        # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('P1', 'task-123')
         await pilot.pause()
-
-        # Mock dismiss
         screen.dismiss = Mock()
-
-        # Mock the selection and value properties
         with (
-            patch.object(
-                type(screen.project_selector), 'selection', new_callable=PropertyMock
-            ) as mock_project,
-            patch.object(
-                type(screen.issue_type_selector), 'selection', new_callable=PropertyMock
-            ) as mock_issue_type,
-            patch.object(type(screen.assignee_selector), 'account_id', new_callable=PropertyMock),
-            patch.object(
-                type(screen.reporter_selector), 'account_id', new_callable=PropertyMock
-            ) as mock_reporter,
-            patch.object(
-                type(screen.parent_key_field), 'value', new_callable=PropertyMock
-            ) as mock_parent,
-            patch.object(
-                type(screen.summary_field), 'value', new_callable=PropertyMock
-            ) as mock_summary,
-            patch.object(
-                DateInputWidget, 'value', new_callable=PropertyMock(return_value='2026-10-10')
-            ),
-            patch.object(SprintWidget, 'get_value_for_create') as mock_sprint_input,
-            patch.object(
-                ADFMarkdownTextAreaWidget, 'get_value_for_create'
-            ) as mock_textarea_adf_markdown,
+            patch.object(SprintWidget, 'get_value_for_create') as mock_sprint_selection,
         ):
-            mock_project.return_value = 'TEST'
-            mock_issue_type.return_value = 'task-123'
-            mock_reporter.return_value = 'reporter123'
-            mock_parent.return_value = 'issue-1'
-            mock_summary.return_value = 'Test Summary'
-            mock_sprint_input.return_value = 101
-            mock_textarea_adf_markdown.return_value = {
-                'type': 'doc',
-                'version': 1,
-                'content': [
-                    {
-                        'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
-                        'type': 'paragraph',
-                    }
-                ],
-            }
+            mock_sprint_selection.return_value = 101
             # WHEN
             screen.handle_save()
 
         # THEN
-        # get the data passed to dismiss
         dismiss_args = screen.dismiss.call_args[0][0]
-        assert len(dismiss_args.keys()) == 11
-        assert dismiss_args['project_key'] == 'TEST'
-        assert dismiss_args['parent_key'] == 'issue-1'
-        assert dismiss_args['issue_type_id'] == 'task-123'
-        assert dismiss_args['summary'] == 'Test Summary'
-        assert dismiss_args['reporter_account_id'] == 'reporter123'
-        assert dismiss_args['duedate'] == '2026-10-10'
-        assert dismiss_args['priority'] == '3'
-        assert dismiss_args['customfield_10147'] == {
-            'type': 'doc',
-            'version': 1,
-            'content': [
-                {
-                    'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
-                    'type': 'paragraph',
-                }
-            ],
-        }
         assert dismiss_args['customfield_10020'] == 101
 
 
 @patch('jiratui.widgets.create_work_item.factory._uses_cloud_api')
+@patch.object(AddWorkItemScreen, '_validate_required_fields')
+@patch.object(AddWorkItemScreen, '_get_sprints_in_project')
 @patch.object(AddWorkItemScreen, 'adf_support_enabled', PropertyMock(return_value=True))
 @patch.object(APIController, 'get_issue_create_metadata')
 @pytest.mark.asyncio
 async def test_save_with_support_for_sprint_input_sprint_not_provided(
     get_issue_create_metadata_mock: AsyncMock,
+    get_sprints_in_project_mock: AsyncMock,
+    validate_required_fields_mock: Mock,
     uses_cloud_api_mock: Mock,
     app,
-    create_metadata_with_editable_reporter: dict,
 ):
     # GIVEN
     app.config.create_additional_fields_ignore_ids = []
     app.config.enable_creating_additional_fields = True
     get_issue_create_metadata_mock.return_value = APIControllerResponse(
-        result=create_metadata_with_editable_reporter
+        result={
+            'fields': [
+                {
+                    'required': True,
+                    'schema': {
+                        'type': 'array',
+                        'items': 'json',
+                        'custom': 'com.pyxis.greenhopper.jira:gh-sprint',
+                        'customId': 10020,
+                    },
+                    'name': 'Sprint',
+                    'key': 'customfield_10020',
+                    'hasDefaultValue': False,
+                    'operations': ['set'],
+                    'fieldId': 'customfield_10020',
+                }
+            ]
+        }
     )
+    get_sprints_in_project_mock.return_value = [('1', 'Sprint 1')]
+    validate_required_fields_mock.return_value = True
     uses_cloud_api_mock.return_value = False
     async with app.run_test() as pilot:
-        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='reporter123')
+        screen = AddWorkItemScreen(project_key='P1', reporter_account_id='reporter123')
         await app.push_screen(screen)
         await pilot.pause()
-
-        # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('P1', 'task-123')
         await pilot.pause()
-
-        # Mock dismiss
         screen.dismiss = Mock()
-
-        # Mock the selection and value properties
         with (
-            patch.object(
-                type(screen.project_selector), 'selection', new_callable=PropertyMock
-            ) as mock_project,
-            patch.object(
-                type(screen.issue_type_selector), 'selection', new_callable=PropertyMock
-            ) as mock_issue_type,
-            patch.object(type(screen.assignee_selector), 'account_id', new_callable=PropertyMock),
-            patch.object(
-                type(screen.reporter_selector), 'account_id', new_callable=PropertyMock
-            ) as mock_reporter,
-            patch.object(
-                type(screen.parent_key_field), 'value', new_callable=PropertyMock
-            ) as mock_parent,
-            patch.object(
-                type(screen.summary_field), 'value', new_callable=PropertyMock
-            ) as mock_summary,
-            patch.object(
-                DateInputWidget, 'value', new_callable=PropertyMock(return_value='2026-10-10')
-            ),
-            patch.object(SprintWidget, 'get_value_for_create') as mock_sprint_input,
-            patch.object(
-                ADFMarkdownTextAreaWidget, 'get_value_for_create'
-            ) as mock_textarea_adf_markdown,
+            patch.object(SprintWidget, 'get_value_for_create') as mock_sprint_selection,
         ):
-            mock_project.return_value = 'TEST'
-            mock_issue_type.return_value = 'task-123'
-            mock_reporter.return_value = 'reporter123'
-            mock_parent.return_value = 'issue-1'
-            mock_summary.return_value = 'Test Summary'
-            mock_sprint_input.return_value = None
-            mock_textarea_adf_markdown.return_value = {
-                'type': 'doc',
-                'version': 1,
-                'content': [
-                    {
-                        'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
-                        'type': 'paragraph',
-                    }
-                ],
-            }
+            mock_sprint_selection.return_value = ''
             # WHEN
             screen.handle_save()
 
         # THEN
-        # get the data passed to dismiss
         dismiss_args = screen.dismiss.call_args[0][0]
-        assert len(dismiss_args.keys()) == 10
-        assert dismiss_args['project_key'] == 'TEST'
-        assert dismiss_args['parent_key'] == 'issue-1'
-        assert dismiss_args['issue_type_id'] == 'task-123'
-        assert dismiss_args['summary'] == 'Test Summary'
-        assert dismiss_args['reporter_account_id'] == 'reporter123'
-        assert dismiss_args['duedate'] == '2026-10-10'
-        assert dismiss_args['priority'] == '3'
-        assert dismiss_args['customfield_10147'] == {
-            'type': 'doc',
-            'version': 1,
-            'content': [
-                {
-                    'content': [{'type': 'text', 'text': 'Some value for the ADF field'}],
-                    'type': 'paragraph',
-                }
-            ],
-        }
         assert 'customfield_10020' not in dismiss_args
 
 
@@ -1221,7 +1018,7 @@ async def test_save_includes_additional_fields_with_adf_support_disabled(
         await pilot.pause()
 
         # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('TEST', 'task-123')
         await pilot.pause()
 
         # Mock dismiss
@@ -1353,7 +1150,7 @@ async def test_jira_field_key(
         await pilot.pause()
         # WHEN
         # trigger metadata fetch
-        await screen.fetch_issue_create_metadata('TEST', 'task-123')
+        await screen._fetch_issue_create_metadata('TEST', 'task-123')
         await pilot.pause()
         screen.handle_save()
         # THEN
@@ -1364,6 +1161,95 @@ async def test_jira_field_key(
         assert screen.parent_key_field.jira_field_key == 'parent_key'
         assert screen.summary_field.jira_field_key == 'summary'
         assert screen.description_field.jira_field_key == 'description'
+
+
+@patch.object(APIController, 'get_issue_create_metadata')
+@pytest.mark.asyncio
+async def test_fetch_issue_create_metadata_without_project_and_type(
+    get_issue_create_metadata_mock: AsyncMock,
+    app,
+):
+    # GIVEN
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='user123')
+        screen.dismiss = Mock()
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN
+        await screen._fetch_issue_create_metadata('', '')
+        get_issue_create_metadata_mock.assert_not_called()
+
+
+@patch.object(AddWorkItemScreen, '_get_sprints_in_project')
+@patch.object(AddWorkItemScreen, '_validate_required_fields')
+@patch.object(APIController, 'get_issue_create_metadata')
+@pytest.mark.asyncio
+async def test_fetch_issue_create_metadata_with_sprint_selection_widgets(
+    get_issue_create_metadata_mock: AsyncMock,
+    validate_required_fields_mock: Mock,
+    get_sprints_in_project_mock: AsyncMock,
+    create_metadata_with_editable_reporter,
+    app,
+):
+    """When we retrieve the item's create-metadata and the sprint field is included and there is a project selected then
+    the screen needs to retrieve the sprints in the project."""
+
+    # GIVEN
+    app.config.create_additional_fields_ignore_ids = []
+    app.config.enable_creating_additional_fields = True
+    get_issue_create_metadata_mock.return_value = APIControllerResponse(
+        result=create_metadata_with_editable_reporter
+    )
+    validate_required_fields_mock.return_value = True
+    get_sprints_in_project_mock.return_value = [('1', 'Sprint 1')]
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='P1', reporter_account_id='user123')
+        screen.dismiss = Mock()
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN
+        await screen._fetch_issue_create_metadata('P1', 'task-123')
+        # THEN
+        get_sprints_in_project_mock.assert_called_once_with('P1')
+
+
+@patch.object(AddWorkItemScreen, '_validate_required_fields')
+@patch.object(APIController, 'get_issue_create_metadata')
+@pytest.mark.asyncio
+async def test_fetch_issue_create_metadata_with_required_description(
+    get_issue_create_metadata_mock: AsyncMock,
+    validate_required_fields_mock: Mock,
+    create_metadata_with_editable_reporter,
+    app,
+):
+    """When we retrieve the item's create-metadata and the description field is included and required then
+    the screen needs to mark the description widget as required."""
+
+    # GIVEN
+    app.config.create_additional_fields_ignore_ids = []
+    app.config.enable_creating_additional_fields = True
+    get_issue_create_metadata_mock.return_value = APIControllerResponse(
+        result={
+            'fields': [
+                {
+                    'fieldId': 'description',
+                    'name': 'Description',
+                    'required': True,
+                    'operations': ['set'],
+                }
+            ]
+        }
+    )
+    validate_required_fields_mock.return_value = True
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='P1', reporter_account_id='user123')
+        screen.dismiss = Mock()
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN
+        await screen._fetch_issue_create_metadata('P1', 'task-123')
+        # THEN
+        assert screen.description_field.border_subtitle == '(*)'
 
 
 def test_create_widgets_for_work_item_creation_additional_fields_with_adf_support_enabled(
@@ -2345,11 +2231,16 @@ async def test_save_button_status_after_description_update(
 
 
 @pytest.mark.parametrize('validate_required_fields', [True, False])
-@patch.object(WorkItemProjectSelectionField, 'selection', PropertyMock(return_value=None))
+@patch.object(AddWorkItemScreen, '_retrieve_applicable_status_codes')
+@patch.object(AddWorkItemScreen, '_fetch_issue_create_metadata')
 @patch.object(AddWorkItemScreen, '_validate_required_fields')
 @pytest.mark.asyncio
 async def test_save_button_status_after_issue_type_selection(
-    validate_required_fields_mock: Mock, validate_required_fields: bool, app
+    validate_required_fields_mock: Mock,
+    fetch_issue_create_metadata_mock: AsyncMock,
+    retrieve_applicable_status_codes_mock: AsyncMock,
+    validate_required_fields: bool,
+    app,
 ):
     # GIVEN
     app.config.create_additional_fields_ignore_ids = []
@@ -2363,6 +2254,8 @@ async def test_save_button_status_after_issue_type_selection(
         screen.handle_issue_type_selection()
         # THEN
         assert screen.save_button.disabled is not validate_required_fields
+        fetch_issue_create_metadata_mock.assert_called_once()
+        retrieve_applicable_status_codes_mock.assert_called_once()
 
 
 @pytest.mark.parametrize('validate_required_fields', [True, False])
@@ -3122,3 +3015,154 @@ async def test_search_work_items_with_advanced_search_enabled_project_selected(
             jql_query='(text ~ "test" OR workItemKey ~ "test") AND (spaceJira = "P1")',
             fields=['id', 'key', 'summary'],
         )
+
+
+@patch.object(APIController, 'get_project_statuses')
+@pytest.mark.asyncio
+async def test_retrieve_applicable_status_codes_without_project_and_type(
+    get_project_statuses_mock: AsyncMock,
+    app,
+):
+    # GIVEN
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='user123')
+        screen.dismiss = Mock()
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN
+        await screen._retrieve_applicable_status_codes('', '')
+        # THEN
+        assert screen.status_selector._options == [('', Select.NULL)]
+        get_project_statuses_mock.assert_not_called()
+
+
+@patch.object(APIController, 'get_project_statuses')
+@pytest.mark.asyncio
+async def test_retrieve_applicable_status_codes_with_project_and_type_no_statuses_found(
+    get_project_statuses_mock: AsyncMock,
+    app,
+):
+    # GIVEN
+    get_project_statuses_mock.return_value = APIControllerResponse(result=None)
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='user123')
+        screen.dismiss = Mock()
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN
+        await screen._retrieve_applicable_status_codes('P1', '1')
+        # THEN
+        assert screen.status_selector._options == [('', Select.NULL)]
+        get_project_statuses_mock.assert_called_once_with('P1')
+
+
+@patch.object(APIController, 'get_project_statuses')
+@pytest.mark.asyncio
+async def test_retrieve_applicable_status_codes_with_project_and_type_statuses_found(
+    get_project_statuses_mock: AsyncMock,
+    app,
+):
+    # GIVEN
+    get_project_statuses_mock.return_value = APIControllerResponse(
+        result={'1': {'issue_type_statuses': [IssueStatus(id='1', name='Todo')]}}
+    )
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='user123')
+        screen.dismiss = Mock()
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN
+        await screen._retrieve_applicable_status_codes('P1', '1')
+        # THEN
+        assert screen.status_selector._options == [('', Select.NULL), ('Todo', '1')]
+        get_project_statuses_mock.assert_called_once_with('P1')
+
+
+@patch.object(AddWorkItemScreen, 'fetch_available_issue_types')
+@patch.object(AddWorkItemScreen, 'fetch_available_projects')
+@pytest.mark.asyncio
+async def test_press_cancel_dismisses_screen_without_data(
+    fetch_available_projects_mock: AsyncMock,
+    fetch_available_issue_types_mock: AsyncMock,
+    app,
+):
+    # GIVEN
+    fetch_available_projects_mock.return_value = APIControllerResponse(
+        result=[Project(id='1', name='P1', key='P1')]
+    )
+    fetch_available_issue_types_mock.return_value = APIControllerResponse(
+        result=[IssueType(id='1', name='Task')]
+    )
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='TEST', reporter_account_id='user123')
+        screen.dismiss = Mock()
+        await app.push_screen(screen)
+        # WHEN
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('escape')
+        await pilot.press('tab')
+        await pilot.press('enter')
+        # THEN
+        dismiss_args = screen.dismiss.call_args[0][0]
+        assert len(dismiss_args.keys()) == 0
+
+
+@patch.object(APIController, 'get_issue_create_metadata')
+@patch.object(TextAreaTabbedContent, '_edit_text_content')
+@patch.object(AddWorkItemScreen, 'fetch_available_issue_types')
+@patch.object(AddWorkItemScreen, 'fetch_available_projects')
+@pytest.mark.asyncio
+async def test_press_edit_on_description_widget_calls_edit_text_content(
+    fetch_available_projects_mock: AsyncMock,
+    fetch_available_issue_types_mock: AsyncMock,
+    edit_text_content_mock: Mock,
+    get_issue_create_metadata_mock: AsyncMock,
+    app,
+):
+    # GIVEN
+    fetch_available_projects_mock.return_value = APIControllerResponse(
+        result=[Project(id='1', name='P1', key='P1')]
+    )
+    fetch_available_issue_types_mock.return_value = APIControllerResponse(
+        result=[IssueType(id='1', name='Task')]
+    )
+    get_issue_create_metadata_mock.return_value = APIControllerResponse(
+        result={
+            'fields': [
+                {
+                    'fieldId': 'description',
+                    'name': 'Description',
+                    'required': True,
+                    'operations': ['set'],
+                },
+            ]
+        }
+    )
+    async with app.run_test() as pilot:
+        screen = AddWorkItemScreen(project_key='P1', reporter_account_id='user123')
+        screen.dismiss = Mock()
+        await app.push_screen(screen)
+        # WHEN
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('a')
+        await pilot.press('tab')
+        await pilot.press('b')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('tab')
+        await pilot.press('ctrl+e')
+        # THEN
+        edit_text_content_mock.assert_called_once_with('')

--- a/src/jiratui/widgets/screen.py
+++ b/src/jiratui/widgets/screen.py
@@ -16,6 +16,7 @@ from jiratui.config import CONFIGURATION
 from jiratui.constants import FULL_TEXT_SEARCH_DEFAULT_MINIMUM_TERM_LENGTH, LOGGER_NAME
 from jiratui.models import (
     IssueType,
+    JiraBaseIssue,
     JiraIssue,
     JiraIssueSearchResponse,
     JiraUser,
@@ -1121,8 +1122,16 @@ class MainScreen(Screen):
         """Handles the event to create a work item after the user clicks on the "save" button in the create-work-item
         screen.
 
+        This method calls the API to create the new work item with the data returned by the create-work-item screen and,
+        if the user set the status of the item then it calls the API to transition item to the desired status.
+
+        If the item is created successfully this method will open the quick-view modal screen (if
+        `config.view_work_item_after_creation = True`) and, if `config.enable_recent_history = True` it will also add
+        the item to the recent history.
+
         Args:
-            data: a dictionary with the details of the fields and values to create the item.
+            data: a dictionary with the details of the fields and values to create the item. This data is provided upon
+            dismissal of the create-work-item modal screen.
 
         Returns:
             None
@@ -1132,7 +1141,7 @@ class MainScreen(Screen):
             self.loading_container.display = True
 
             # split data into base fields and dynamic fields (custom fields, components, etc.)
-            # Base fields are handled explicitly by the controller
+            # base fields are handled explicitly by the controller
             base_fields = {
                 'project_key',
                 'parent_key',
@@ -1143,29 +1152,41 @@ class MainScreen(Screen):
                 'description',
                 'duedate',
                 'priority',
+                'status',
             }
-
-            # Separate base data from dynamic fields (custom fields, components, etc.)
+            # separate base data from dynamic fields (custom fields, components, etc.)
             base_data = {k: v for k, v in data.items() if k in base_fields}
             dynamic_fields = {k: v for k, v in data.items() if k not in base_fields}
-
             # request the API to create the work item
             response: APIControllerResponse = await self.api.create_work_item(
                 base_data, **dynamic_fields
             )
-            self.loading_container.display = False
-
-            if response.success and response.result:
+            created_work_item: JiraBaseIssue | None
+            if response.success and (created_work_item := response.result):
+                new_status: str | None
+                # check if the user wants to set the new item's status; i.e. transition the item to a different status
+                if (new_status := data.get('status')) is not None:
+                    response = await self.api.transition_issue_status(
+                        created_work_item.key, new_status
+                    )
+                    self.loading_container.display = False
+                    if not response.success:
+                        self.notify(
+                            f'Failed to transition the work item to a different status: {response.error}',
+                            severity='error',
+                            title='Status Transition',
+                        )
+                self.loading_container.display = False
                 self.notify(
-                    f'Work item {response.result.key} created successfully',
+                    f'Work item {created_work_item.key} created successfully',
                     title='Create Work Item',
                 )
                 if self.config.view_work_item_after_creation:
-                    self.call_next(self._open_quick_view_screen, response.result.key)
+                    self.call_next(self._open_quick_view_screen, created_work_item.key)
                 if self.config.enable_recent_history:
-                    # add the work item to the recent history
-                    self._add_item_to_recent_history(response.result.key, '', '', '')
+                    self._add_item_to_recent_history(created_work_item.key, '', '', '')
             else:
+                self.loading_container.display = False
                 self.notify(
                     f'Failed to create the work item: {response.error}',
                     severity='error',


### PR DESCRIPTION
This PR updates the form/screen that allows users to create work items to allow them to specify the status of the work item.

The status is optional but when the user defines the application will transition the item to the new status after creating the work item.

<img width="1427" height="461" alt="Screenshot 2026-07-18 at 14 46 25" src="https://github.com/user-attachments/assets/3d4c53df-a5bd-4a08-8c58-967289350638" />

Closes https://github.com/whyisdifficult/jiratui/issues/82