### PR TITLE
fix: make summary truncation configurable in CLI search results

### DIFF
--- a/src/jiratui/commands/render.py
+++ b/src/jiratui/commands/render.py
@@ -196,7 +196,9 @@ class JiraIssueSearchRenderer(Renderer):
                 issue.display_status(),
                 issue.display_reporter(),
                 issue.display_assignee(),
-                issue.cleaned_summary(20),
+                issue.cleaned_summary(
+                    CONFIGURATION.get().cli_search_results_truncate_work_item_summary
+                ),
             )
         console.print(table)
 

--- a/src/jiratui/config.py
+++ b/src/jiratui/config.py
@@ -156,6 +156,9 @@ class ApplicationConfiguration(BaseSettings):
     search_results_truncate_work_item_summary: int | None = None
     """When this is defined the summary of a work item will be truncated to the specified length when it is displayed in
     the search results."""
+    cli_search_results_truncate_work_item_summary: int | None = 20
+    """When this is defined the summary of a work item will be truncated to the specified length when it is displayed in
+    the search results for cli tool."""
     search_results_style_work_item_status: bool = True
     """If `True` (default) the status of a work item will be styled when it is displayed in the search results."""
     search_results_style_work_item_type: bool = True

--- a/src/jiratui/models.py
+++ b/src/jiratui/models.py
@@ -258,8 +258,14 @@ class RelatedJiraIssue(BaseModel):
         return self.priority.name if self.priority else ''
 
     def cleaned_summary(self, max_length: int | None = None) -> str:
-        if max_length is not None:
-            return f'{self.summary.strip()[:max_length]}...'
+        if max_length is not None and max_length > 0:
+            if (stripped_summary := self.summary.strip()) and len(stripped_summary) > max_length:
+                suffix = '...'
+                end_idx = max_length - len(suffix)
+                if max_length <= len(suffix):
+                    suffix = ''
+                    end_idx = max_length
+                return f'{stripped_summary[:end_idx]}{suffix}'
         return self.summary.strip()
 
     def display_status(self) -> str:
@@ -395,11 +401,14 @@ class JiraIssue(JiraBaseIssue):
         return f'{self.key.strip()} - {self.summary.strip()}'
 
     def cleaned_summary(self, max_length: int | None = None) -> str:
-        if max_length is not None:
-            if (stripped_summary := self.summary.strip()) and len(
-                stripped_summary
-            ) > max_length - 3:
-                return f'{stripped_summary[: max_length - 3]}...'
+        if max_length is not None and max_length > 0:
+            if (stripped_summary := self.summary.strip()) and len(stripped_summary) > max_length:
+                suffix = '...'
+                end_idx = max_length - len(suffix)
+                if max_length <= len(suffix):
+                    suffix = ''
+                    end_idx = max_length
+                return f'{stripped_summary[:end_idx]}{suffix}'
         return self.summary.strip()
 
     def display_status(self) -> str:

--- a/src/jiratui/tests/test_commands.py
+++ b/src/jiratui/tests/test_commands.py
@@ -1,0 +1,50 @@
+import io
+from unittest.mock import Mock
+
+import pytest
+from rich.console import Console
+
+from jiratui.commands.render import JiraIssueSearchRenderer
+from jiratui.config import CONFIGURATION, ApplicationConfiguration
+from jiratui.models import IssueStatus, IssueType, JiraIssue, JiraIssueSearchResponse
+
+
+@pytest.fixture()
+def configuration():
+    config_mock = Mock(spec=ApplicationConfiguration)
+    token = CONFIGURATION.set(config_mock)
+    yield config_mock
+    CONFIGURATION.reset(token)
+
+
+def _rendered_search_results(console_file: io.StringIO, summary: str) -> str:
+    issue = JiraIssue(
+        id='1',
+        key='TEST-1',
+        summary=summary,
+        status=IssueStatus(id='1', name='To Do'),
+        issue_type=IssueType(id='1', name='Task'),
+    )
+    console = Console(file=console_file, width=250)
+    JiraIssueSearchRenderer().render(console, JiraIssueSearchResponse(issues=[issue]))
+    return console_file.getvalue()
+
+
+def test_search_renderer_truncates_summary_using_cli_config(configuration):
+    configuration.configure_mock(cli_search_results_truncate_work_item_summary=10)
+    output = _rendered_search_results(io.StringIO(), 'a much longer summary')
+    assert 'a much ...' in output
+    assert 'longer' not in output
+
+
+@pytest.mark.parametrize(
+    'config_value',
+    (0, None),
+    ids=('zero', 'None'),
+)
+def test_search_renderer_does_not_truncate_summary_when_cli_config_is_unset(
+    configuration, config_value
+):
+    configuration.configure_mock(cli_search_results_truncate_work_item_summary=config_value)
+    output = _rendered_search_results(io.StringIO(), 'the full summary is shown')
+    assert 'the full summary is shown' in output

--- a/src/jiratui/tests/test_models.py
+++ b/src/jiratui/tests/test_models.py
@@ -1,0 +1,42 @@
+import pytest
+
+from jiratui.models import IssueStatus, IssueType, JiraIssue, RelatedJiraIssue
+
+
+def _jira_issue(summary: str) -> JiraIssue:
+    return JiraIssue(
+        id='1',
+        key='TEST-1',
+        summary=summary,
+        status=IssueStatus(id='1', name='To Do'),
+    )
+
+
+def _related_jira_issue(summary: str) -> RelatedJiraIssue:
+    return RelatedJiraIssue(
+        id='1',
+        key='TEST-1',
+        summary=summary,
+        status=IssueStatus(id='1', name='To Do'),
+        issue_type=IssueType(id='1', name='Task'),
+    )
+
+
+@pytest.mark.parametrize('issue_factory', [_jira_issue, _related_jira_issue])
+@pytest.mark.parametrize(
+    'summary, max_length, expected',
+    [
+        ('  a summary  ', None, 'a summary'),  # strips whitespace, no truncation
+        ('a summary', 0, 'a summary'),  # zero disables truncation
+        ('a summary', -3, 'a summary'),  # negative values disable truncation
+        ('short', 10, 'short'),  # shorter than the limit stays untouched
+        ('exactlyten', 10, 'exactlyten'),  # exactly the limit stays untouched
+        ('a summary that is quite long', 20, 'a summary that is...'),  # truncated to max_length
+        ('long summary here', 4, 'l...'),  # suffix fits within max_length
+        ('long summary here', 3, 'lon'),  # max_length <= len('...') cuts without suffix
+        ('long summary here', 2, 'lo'),
+        ('   ', None, ''),
+    ],
+)
+def test_cleaned_summary(issue_factory, summary, max_length, expected):
+    assert issue_factory(summary).cleaned_summary(max_length) == expected


### PR DESCRIPTION
Fixes #296

## What
- Adds a `cli_search_results_truncate_work_item_summary` config setting (default 20, preserving current behavior)
- Wires `JiraIssueSearchRenderer` to use it instead of the hardcoded length
- Fixes `cleaned_summary()` in `JiraIssue` and `RelatedJiraIssue`: `...` is only appended on actual truncation, output never exceeds the configured length, and `0`/`None` disables truncation

## Tests
- Added tests in `test_commands.py` and `test_models.py`