### PR TITLE
JT-75: add support for updating the sprint of a work item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ project. By [@whyisdifficult](https://github.com/whyisdifficult) in https://gith
 - Add config variable `enable_logging` to enable/disable logging. The default is `False`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/294
 - Add support for specifying the status of a work item being created. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/295
 - Add support for updating the sprint of a work item. This is only supported when the JiraTUI connects to the Jira Cloud
-Platform. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
+Platform. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/298
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This feature uses the Jira Software Cloud REST API. By [@whyisdifficult](https:/
 project. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/293
 - Add config variable `enable_logging` to enable/disable logging. The default is `False`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/294
 - Add support for specifying the status of a work item being created. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/295
+- Add support for updating the sprint of a work item. This is only supported when the JiraTUI connects to the Jira Cloud
+Platform. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/
 
 ### Bug Fixes
 

--- a/src/jiratui/api_controller/factories.py
+++ b/src/jiratui/api_controller/factories.py
@@ -25,16 +25,16 @@ from jiratui.utils.fields import get_additional_fields_values, get_custom_fields
 class WorkItemFactory:
     @staticmethod
     def create_work_item(data: dict) -> JiraIssue:
-        """Creates an instance of [JiraIssue](#jiratui.models.JiraIssue) for a work item as returned by the API.
+        """Creates an instance of [JiraIssue](#jiratui.models.JiraIssue) from the work item data as returned by the API.
 
         Args:
-            data: the work item as returned by the API.
+            data: the work item data as returned by the API.
 
         Returns:
             An instance of `JiraIssue` with the value of the work item's fields supported by the app.
         """
 
-        fields: dict = data.get('fields', {})
+        fields: dict[str, Any] = data.get('fields', {})
         project: dict = fields.get(JiraWorkItemFields.PROJECT.value, {})
         status: dict = fields.get(JiraWorkItemFields.STATUS.value, {})
         assignee: dict | None = fields.get(JiraWorkItemFields.ASSIGNEE.value)
@@ -59,11 +59,11 @@ class WorkItemFactory:
 
         sprint: JiraSprint | None = None
         if sprint_custom_field_id := CONFIGURATION.get().custom_field_id_sprint:
-            if sprint_ids := fields.get(sprint_custom_field_id):
+            if sprint_data := fields.get(sprint_custom_field_id):
                 sprint = JiraSprint(
-                    id=sprint_ids[0].get('id'),
-                    name=sprint_ids[0].get('name'),
-                    active=sprint_ids[0].get('active'),
+                    id=str(sprint_data[0].get('id', '')),
+                    name=sprint_data[0].get('name'),
+                    active=sprint_data[0].get('active') or False,
                 )
 
         attachments: list[Attachment] = []
@@ -100,8 +100,8 @@ class WorkItemFactory:
 
         # extract the value of the issue's custom fields
         custom_fields_values: dict[str, Any] | None = None
-        if editmeta := data.get('editmeta', {}):
-            custom_fields_values = get_custom_fields_values(fields, editmeta.get('fields', {}))
+        if edit_meta := data.get('editmeta', {}):
+            custom_fields_values = get_custom_fields_values(fields, edit_meta.get('fields', {}))
 
         # extract the value of the issue's additional fields
         additional_fields: dict[str, Any] = get_additional_fields_values(
@@ -110,13 +110,13 @@ class WorkItemFactory:
         )
 
         return JiraIssue(
-            id=data.get('id'),
-            key=data.get('key'),
+            id=str(data.get('id')),
+            key=str(data.get('key')),
             summary=fields.get(JiraWorkItemFields.SUMMARY.value, ''),
             description=fields.get(JiraWorkItemFields.DESCRIPTION.value),
             project=Project(
                 id=project.get('id'),
-                name=project.get('name'),
+                name=project.get('name', ''),
                 key=project.get('key'),
             )
             if project

--- a/src/jiratui/models.py
+++ b/src/jiratui/models.py
@@ -958,7 +958,7 @@ class AgileSprint(BaseModel):
     id: int
     name: str
     state: AgileSprintState
-    goal: str
+    goal: str | None = None
     origin_board_id: int | None = None
     origin_board_name: str | None = None
     start_date: datetime | None = None

--- a/src/jiratui/widgets/commons/widgets.py
+++ b/src/jiratui/widgets/commons/widgets.py
@@ -2164,17 +2164,17 @@ class SprintSelectionWidget(Select, BaseFieldWidget, BaseUpdateFieldWidget):
         """Initializes a [Select](#textual.widgets.Select).
 
         Args:
-            mode: The field mode (CREATE or UPDATE)
-            field_id: Field identifier (Jira field key)
+            mode: the field mode (CREATE or UPDATE)
+            field_id: field identifier (Jira field key)
             jira_field_key: the key of the field that it is used for updating the field value in the API.
-            options: List of (display_name, value) tuples for the dropdown
-            title: Display title (defaults to field_id)
-            required: Whether the field is required (mainly for CREATE mode)
-            initial_value: Initial selected value (CREATE mode only)
-            original_value: Original value from Jira (UPDATE mode only)
-            field_supports_update: Whether field can be updated (UPDATE mode only)
-            allow_blank: Whether to allow blank/empty selection
-            prompt: Prompt text for the dropdown
+            options: list of (display_name, value) tuples for the dropdown
+            title: display title (defaults to field_id)
+            required: whether the field is required (mainly for CREATE mode)
+            initial_value: initial selected value (CREATE mode only)
+            original_value: original value from Jira (UPDATE mode only)
+            field_supports_update: whether field can be updated (UPDATE mode only)
+            allow_blank: whether to allow blank/empty selection
+            prompt: prompt text for the dropdown
         """
 
         # Determine the appropriate prompt
@@ -2190,7 +2190,7 @@ class SprintSelectionWidget(Select, BaseFieldWidget, BaseUpdateFieldWidget):
             type_to_search=True,
         )
 
-        # Setup base field properties
+        # setup base field properties
         self.setup_base_field(
             mode=mode,
             field_id=field_id,
@@ -2208,7 +2208,7 @@ class SprintSelectionWidget(Select, BaseFieldWidget, BaseUpdateFieldWidget):
                 original_value=original_value,
                 field_supports_update=field_supports_update,
             )
-            # Set initial value for UPDATE mode
+            # set initial value for UPDATE mode
             if original_value is not None:
                 self.value = original_value
         else:
@@ -2246,8 +2246,7 @@ class SprintSelectionWidget(Select, BaseFieldWidget, BaseUpdateFieldWidget):
 
     @property
     def value_has_changed(self) -> bool:
-        """
-        Determines if the current value differs from the original value (UPDATE mode).
+        """Determines if the current value differs from the original value (UPDATE mode).
 
         Returns:
             True if value has changed, False otherwise
@@ -2255,14 +2254,14 @@ class SprintSelectionWidget(Select, BaseFieldWidget, BaseUpdateFieldWidget):
         if self.mode != FieldMode.UPDATE:
             raise ValueError('value_has_changed only valid in UPDATE mode')
 
-        # No original value
+        # no original value
         if not self.original_value:
-            # Changed if we now have a selection
+            # changed if we now have a selection
             return bool(self.selection)
 
-        # Had original value, now no selection
+        # had original value, now no selection
         if not self.selection:
             return True
 
-        # Both exist - compare them
+        # both exist - compare them
         return self.original_value != self.selection

--- a/src/jiratui/widgets/create_work_item/screen.py
+++ b/src/jiratui/widgets/create_work_item/screen.py
@@ -709,14 +709,12 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
 
         if not key:
             return None
-        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
-        sprints: dict[str, list[AgileSprint]] = self._get_sprints_from_application_session(
-            application
-        )
+        sprints: dict[str, list[AgileSprint]] = self._get_sprints_from_application_session()
         if not sprints or not sprints.get(key):
             sprints_in_project: list[AgileSprint] | None
             response: APIControllerResponse = await self.app.api.get_project_sprints(key)  # type:ignore[attr-defined]
             if response.success and (sprints_in_project := response.result):
+                application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
                 if not sprints:
                     application.session.sprints = {key: sprints_in_project}
                 else:
@@ -724,8 +722,8 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
                     application.session.sprints = sprints
         return None
 
-    @staticmethod
-    def _get_sprints_from_application_session(application) -> dict[str, list[AgileSprint]]:
+    def _get_sprints_from_application_session(self) -> dict[str, list[AgileSprint]]:
+        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
         return application.session.get('sprints', {})
 
     async def _get_sprints_in_project(self, key: str | None = None) -> list[tuple[str, str]]:
@@ -740,10 +738,8 @@ class AddWorkItemScreen(Screen[dict[str, Any]]):
 
         if not key:
             return []
-        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
-        sprints: dict[str, list[AgileSprint]] = self._get_sprints_from_application_session(
-            application
-        )
+
+        sprints: dict[str, list[AgileSprint]] = self._get_sprints_from_application_session()
         return [(sprint.display_name, str(sprint.id)) for sprint in sprints.get(key, [])]
 
     async def _remove_textarea_panes(self) -> None:

--- a/src/jiratui/widgets/screen.py
+++ b/src/jiratui/widgets/screen.py
@@ -1467,14 +1467,18 @@ class MainScreen(Screen):
         self._load_work_item(work_item_key)
 
     def _add_item_to_recent_history(
-        self, key: str, item_type: str, status: str, summary: str
+        self,
+        key: str,
+        item_type: str | None = None,
+        status: str | None = None,
+        summary: str | None = None,
     ) -> None:
         self.__recent_history_manager.add_work_item(
             HistoryEntry(
                 key=key,
-                item_type=item_type,
-                status=status,
-                summary=summary,
+                item_type=item_type or '',
+                status=status or '',
+                summary=summary or '',
             )
         )
 

--- a/src/jiratui/widgets/work_item_details/details.py
+++ b/src/jiratui/widgets/work_item_details/details.py
@@ -61,12 +61,13 @@ from textual.binding import Binding
 from textual.containers import Center, HorizontalGroup, ItemGrid, Right, Vertical, VerticalScroll
 from textual.message import Message
 from textual.reactive import Reactive, reactive
+from textual.widget import Widget
 from textual.widgets import LoadingIndicator, ProgressBar
 
 from jiratui.api_controller.controller import APIControllerResponse
 from jiratui.config import CONFIGURATION
 from jiratui.exceptions import UpdateWorkItemException, ValidationError
-from jiratui.models import IssuePriority, JiraIssue, TimeTracking
+from jiratui.models import AgileSprint, IssuePriority, JiraIssue, TimeTracking
 from jiratui.utils.work_item_updates import (
     work_item_assignee_has_changed,
     work_item_parent_has_changed,
@@ -85,6 +86,7 @@ from jiratui.widgets.commons.widgets import (
     NumericInputWidget,
     SelectionWidget,
     SingleUserPickerWidget,
+    SprintSelectionWidget,
     TextInputWidget,
     URLWidget,
 )
@@ -245,8 +247,8 @@ class IssueDetailsWidget(Vertical):
         return self.query_one(IssueParentField)
 
     @property
-    def issue_sprint_field(self) -> IssueSprintField:
-        return self.query_one(IssueSprintField)
+    def issue_sprint_field(self) -> IssueSprintField | None:
+        return self.query_one_optional(IssueSprintField)
 
     @property
     def issue_resolution_field(self) -> ReadOnlyTextField:
@@ -296,6 +298,14 @@ class IssueDetailsWidget(Vertical):
     def content_container(self) -> VerticalScroll:
         return self.query_one('#issue-details-form', expect_type=VerticalScroll)
 
+    @property
+    def support_sprint_selection(self) -> bool:
+        return CONFIGURATION.get().cloud
+
+    @property
+    def support_updating_additional_fields(self) -> bool:
+        return CONFIGURATION.get().enable_updating_additional_fields
+
     def show_loading(self) -> None:
         """Shows the loading indicator and hides content."""
         self.loading_container.display = True
@@ -331,7 +341,8 @@ class IssueDetailsWidget(Vertical):
                 yield IssueKeyField()
                 # set widgets in row 4
                 yield IssueParentField()
-                yield IssueSprintField()
+                if not self.support_sprint_selection:
+                    yield IssueSprintField()
                 yield IssueTypeField()
                 # set widgets in row 5
                 # this input field contains the id of the Jira user that we can use to update the item's reporter field
@@ -532,17 +543,19 @@ class IssueDetailsWidget(Vertical):
             self.issue_key_field.clear()
             self.project_id_field.clear()
             self.issue_type_field.clear()
-            self.issue_sprint_field.clear()
             self.issue_status_selector.clear()
             self.assignee_selector.clear()
             self.reporter_selector.clear()
             self.priority_selector.clear()
             self.priority_selector.update_enabled = True
             self.issue_due_date_field.set_original_value(None)
+            if widget := self.issue_sprint_field:
+                widget.clear()
             self._work_item_is_flagged = None
             self._issue_supports_flagging = True
             self.work_item_flag_widget.show = False
             self.time_tracking_container.remove_children()
+            # clear all the dynamically-generated widgets
             self.dynamic_fields_widgets_container.remove_children()
 
     def _setup_time_tracking(self, time_tracking_data: TimeTracking | None = None) -> None:
@@ -653,6 +666,7 @@ class IssueDetailsWidget(Vertical):
                     and not isinstance(dynamic_widget, LabelsWidget)
                     and not isinstance(dynamic_widget, MultiUserPickerWidget)
                     and not isinstance(dynamic_widget, SingleUserPickerWidget)
+                    and not isinstance(dynamic_widget, SprintSelectionWidget)
                 ):
                     continue
                 if dynamic_widget.value_has_changed:
@@ -710,7 +724,7 @@ class IssueDetailsWidget(Vertical):
                 self.notify(
                     f'Data validation error: {e}',
                     severity='error',
-                    title='Update Work Item',
+                    title='Validation Error',
                 )
             except Exception as e:
                 self.notify(str(e), severity='error', title='Update Work Item')
@@ -720,9 +734,10 @@ class IssueDetailsWidget(Vertical):
                     issue_was_updated = True
                 else:
                     self.notify(
-                        'The work item was not updated.', severity='error', title='Update Work Item'
+                        f'The work item was not updated: {response.error or ""}',
+                        severity='error',
+                        title='Update Work Item',
                     )
-                    self.notify(response.error, severity='error', title='Update Work Item')
 
         if issue_requires_transition:
             response = await application.api.transition_issue_status(
@@ -838,6 +853,46 @@ class IssueDetailsWidget(Vertical):
             if current_status_id and work_status_codes_options:
                 self.issue_status_selector.value = current_status_id
 
+    async def _fetch_sprints_in_project(self, project_key: str) -> list[AgileSprint] | None:
+        """Retrieves the sprints of a project and updates the data in the application's session.
+
+        This function attempts to get the data from the application's session to avoid making unnecessary API
+        requests. If the session does not have the data then it fetches the sprints from the API and updates the
+        application's session.
+
+        Args:
+            project_key: the key or id of the project/space whose sprints we want to retrieve.
+
+        Returns:
+            A list of AgileSprint with the details of the active and future sprints in the project/space.
+        """
+
+        if not project_key:
+            return None
+
+        sprints: dict[str, list[AgileSprint]] = self._get_sprints_from_application_session()
+
+        sprints_in_project: list[AgileSprint] | None
+        if sprints_in_project := sprints.get(project_key):
+            return sprints_in_project
+
+        # retrieve the project's sprints
+        response: APIControllerResponse = await self.app.api.get_project_sprints(project_key)  # type:ignore[attr-defined]
+        if response.success and (sprints_in_project := response.result):
+            application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
+            if not sprints:
+                application.session.sprints = {project_key: sprints_in_project}
+            else:
+                sprints[project_key] = sprints_in_project
+                application.session.sprints = sprints
+            return sprints_in_project
+
+        return None
+
+    def _get_sprints_from_application_session(self) -> dict[str, list[AgileSprint]]:
+        application = cast('JiraApp', self.app)  # type:ignore[name-defined] # noqa: F821
+        return application.session.get('sprints', {})
+
     def watch_issue(self, work_item: JiraIssue | None) -> None:
         """Updates the form fields with the details of the work item selected by the user.
 
@@ -853,7 +908,7 @@ class IssueDetailsWidget(Vertical):
             work_item: a work item selected by the user in the left-hand side panel.
 
         Returns:
-            None.
+            None
         """
 
         # "reset" the form by setting the value of all its elements to the default
@@ -899,6 +954,8 @@ class IssueDetailsWidget(Vertical):
         self.reporter_selector.update_enabled = editable_fields.get('reporter')
 
         # set the value of the form fields based on the work item's data
+        if not self.support_sprint_selection:
+            self.issue_sprint_field.value = work_item.sprint_name
         self.issue_last_update_date_field.value = work_item.updated_on
         self.issue_created_date_field.value = work_item.created_on
         self.issue_resolution_date_field.value = work_item.resolved_on
@@ -915,7 +972,6 @@ class IssueDetailsWidget(Vertical):
         self.issue_parent_field.jira_field_is_required = required_fields.get(
             self.issue_parent_field.jira_field_key
         )
-        self.issue_sprint_field.value = work_item.sprint_name
         self.issue_summary_field.value = work_item.summary
         self.issue_summary_field.update_enabled = editable_fields.get(
             self.issue_summary_field.jira_field_key
@@ -932,43 +988,51 @@ class IssueDetailsWidget(Vertical):
         # check if the work item has been flagged; and show a label at the top with a message for the user
         self.run_worker(self._determine_issue_flagged_status(work_item))
 
-        if CONFIGURATION.get().enable_updating_additional_fields:
-            # add dynamic widgets to support updating additional fields including custom fields and other system fields
+        if self.support_updating_additional_fields:
+            # add dynamic widgets to support updating custom fields and other system fields
             self.run_worker(self._add_dynamic_widgets(work_item))
 
     async def _add_dynamic_widgets(self, work_item: JiraIssue) -> None:
-        """Builds and mounts a list of (dynamic) widgets to support updating (some) system and custom field types
+        """Builds and mounts a list of (dynamic) widgets to support updating (some) system and custom field types.
 
         This method sorts the dynamic widgets before mounting them so `MultiUserPickerWidget` instances appear
         first. This ensures that the autocomplete feature for multi-user picker widgets works well in the UI and that
         `Textarea` fields with rendered Markdown are displayed at the bottom.
 
+        The method updates the `DynamicFieldsWidgets` widget by mounting all the dynamic widgets that were created.
+
         Args:
-            work_item: the work item.
+            work_item: the method generates widgets for the system and custom fields of this item.
 
         Returns:
-            None; updates the `DynamicFieldsWidgets` widget.
+            None
         """
 
         # get filter configuration to ignore fields from the dynamic form
         ignore_filter_ids = CONFIGURATION.get().update_additional_fields_ignore_ids
         await self.dynamic_fields_widgets_container.remove_children()
+        dynamic_widgets: list[Widget]
         if dynamic_widgets := create_dynamic_widgets_for_updating_work_item(
-            work_item,
-            ignore_filter_ids=ignore_filter_ids,
+            work_item, ignore_filter_ids=ignore_filter_ids
         ):
             user_picker_widgets: list[MultiUserPickerWidget | SingleUserPickerWidget] = []
-            other_widgets = []
+            other_widgets: list[Widget] = []
+            sprint_selection_widgets: list[SprintSelectionWidget] = []
             for dynamic_widget in dynamic_widgets:
                 if isinstance(dynamic_widget, MultiUserPickerWidget) or isinstance(
                     dynamic_widget, SingleUserPickerWidget
                 ):
                     user_picker_widgets.append(dynamic_widget)
+                elif isinstance(dynamic_widget, SprintSelectionWidget):
+                    sprint_selection_widgets.append(dynamic_widget)
                 else:
                     other_widgets.append(dynamic_widget)
-            sorted_widgets = user_picker_widgets + other_widgets
+
+            sorted_widgets = user_picker_widgets + sprint_selection_widgets + other_widgets
+
             # mount the dynamic widgets
             await self.dynamic_fields_widgets_container.mount(*sorted_widgets)
+
             # mount autocomplete widgets for the dynamic widgets that require them
             for widget in self.dynamic_fields_widgets_container.query(MultiUserPickerWidget):
                 await self.dynamic_fields_widgets_container.mount(
@@ -982,6 +1046,27 @@ class IssueDetailsWidget(Vertical):
                 await self.dynamic_fields_widgets_container.mount(
                     LabelsAutoComplete(target=widget, api_controller=self.app.api)  # type:ignore
                 )
+            if self.support_sprint_selection and sprint_selection_widgets:
+                # fetch the sprints associated to the item's project and store them in the application's session
+                sprints: list[AgileSprint] | None = await self._fetch_sprints_in_project(
+                    work_item.project.key
+                )
+                if sprints:
+                    current_sprint_id: str | None = None
+                    sprint_ids: set[str] = {str(sprint.id) for sprint in sprints}
+                    if work_item.sprint and str(work_item.sprint.id) in sprint_ids:
+                        current_sprint_id = str(work_item.sprint.id)
+
+                    # set the options for every sprint selection widget
+                    for widget in self.dynamic_fields_widgets_container.query(
+                        SprintSelectionWidget
+                    ):
+                        widget.set_options(
+                            [(sprint.display_name, str(sprint.id)) for sprint in sprints]
+                        )
+                        if current_sprint_id:
+                            widget.value = current_sprint_id
+                        # TODO update required field after setting the options
 
     async def _determine_issue_flagged_status(self, issue: JiraIssue) -> None:
         application = cast('JiraApp', self.app)  # type: ignore[name-defined] # noqa: F821

--- a/src/jiratui/widgets/work_item_details/details.py
+++ b/src/jiratui/widgets/work_item_details/details.py
@@ -1058,15 +1058,14 @@ class IssueDetailsWidget(Vertical):
                         current_sprint_id = str(work_item.sprint.id)
 
                     # set the options for every sprint selection widget
-                    for widget in self.dynamic_fields_widgets_container.query(
+                    for sprint_widget in self.dynamic_fields_widgets_container.query(
                         SprintSelectionWidget
                     ):
-                        widget.set_options(
+                        sprint_widget.set_options(
                             [(sprint.display_name, str(sprint.id)) for sprint in sprints]
                         )
                         if current_sprint_id:
-                            widget.value = current_sprint_id
-                        # TODO update required field after setting the options
+                            sprint_widget.value = current_sprint_id
 
     async def _determine_issue_flagged_status(self, issue: JiraIssue) -> None:
         application = cast('JiraApp', self.app)  # type: ignore[name-defined] # noqa: F821

--- a/src/jiratui/widgets/work_item_details/factory.py
+++ b/src/jiratui/widgets/work_item_details/factory.py
@@ -6,11 +6,18 @@ from typing import Any
 
 from dateutil.parser import isoparse  # type:ignore[import-untyped]
 from textual.widget import Widget
+from textual.widgets import Select
 
+from jiratui.config import CONFIGURATION
 from jiratui.models import JiraIssue
 from jiratui.widgets.commons import CustomFieldType, FieldMode
 from jiratui.widgets.commons.factory_utils import AllowedValuesParser, FieldMetadata, WidgetBuilder
-from jiratui.widgets.commons.widgets import LabelsWidget, MultiSelectWidget, MultiUserPickerWidget
+from jiratui.widgets.commons.widgets import (
+    LabelsWidget,
+    MultiSelectWidget,
+    MultiUserPickerWidget,
+    SprintSelectionWidget,
+)
 
 
 class WorkItemManualUpdateFieldKeys(Enum):
@@ -54,6 +61,11 @@ class WorkItemUnsupportedUpdateFieldKeys(Enum):
     ISSUE_TYPE = 'issuetype'
     SPRINT = 'sprint'
     TEAM = 'team'
+
+
+def _uses_cloud_api() -> bool:
+    config = CONFIGURATION.get()
+    return config.cloud
 
 
 def create_dynamic_widgets_for_updating_work_item(
@@ -212,7 +224,7 @@ def create_dynamic_widgets_for_updating_work_item(
                     jira_field_key=metadata.key,
                     options=options,
                     title=field.get('name'),
-                    required=field.get('required', False),
+                    required=metadata.required,
                     original_value=current_ids,
                     field_supports_update=metadata.supports_update,
                 )
@@ -299,6 +311,26 @@ def create_dynamic_widgets_for_updating_work_item(
                         options=options,
                         current_value=value,
                     )
+            elif schema_custom_type == CustomFieldType.SPRINT.value and _uses_cloud_api():
+                # set the current value (original_value) of the widget base don the current sprint (if any) of the item
+                initial_options: list[tuple[str, str]] = []
+                if work_item.sprint:
+                    initial_options = [
+                        ('', Select.NULL),
+                        (work_item.sprint.name, str(work_item.sprint.id)),
+                    ]
+                widget = SprintSelectionWidget(
+                    mode=FieldMode.UPDATE,
+                    field_id=metadata.field_id,
+                    jira_field_key=metadata.key,
+                    options=initial_options,
+                    title=metadata.name,
+                    required=False,
+                    original_value=str(work_item.sprint.id) if work_item.sprint else None,
+                    field_supports_update=metadata.supports_update,
+                    allow_blank=not metadata.required,
+                    prompt=f'Select {metadata.name}',
+                )
         else:
             # process the non-custom fields based on the schema type
             if schema.get('system', '').lower() == 'labels':

--- a/src/jiratui/widgets/work_item_details/factory.py
+++ b/src/jiratui/widgets/work_item_details/factory.py
@@ -316,7 +316,7 @@ def create_dynamic_widgets_for_updating_work_item(
                 initial_options: list[tuple[str, str]] = []
                 if work_item.sprint:
                     initial_options = [
-                        ('', Select.NULL),
+                        ('', Select.NULL),  # type:ignore[list-item]
                         (work_item.sprint.name, str(work_item.sprint.id)),
                     ]
                 widget = SprintSelectionWidget(

--- a/src/jiratui/widgets/work_item_details/tests/test_issue_details_widget.py
+++ b/src/jiratui/widgets/work_item_details/tests/test_issue_details_widget.py
@@ -9,6 +9,8 @@ from jiratui.api_controller.controller import APIController, APIControllerRespon
 from jiratui.app import JiraApp
 from jiratui.exceptions import UpdateWorkItemException, ValidationError
 from jiratui.models import (
+    AgileSprint,
+    AgileSprintState,
     Attachment,
     IssuePriority,
     IssueStatus,
@@ -30,12 +32,14 @@ from jiratui.widgets.commons.widgets import (
     MultiUserPickerWidget,
     NumericInputWidget,
     SingleUserPickerWidget,
+    SprintSelectionWidget,
 )
 from jiratui.widgets.screen import WorkItemSearchResult
 from jiratui.widgets.work_item_details.details import IssueDetailsWidget
 from jiratui.widgets.work_item_details.fields import (
     IssueDetailsPrioritySelection,
     IssueDetailsStatusSelection,
+    IssueSprintField,
     WorkItemDetailsDueDate,
 )
 from jiratui.widgets.work_item_details.flag_work_item import FlagWorkItemScreen
@@ -270,7 +274,7 @@ async def test_search_users_by_issue_key(
 @patch('jiratui.widgets.screen.MainScreen.fetch_issue_types')
 @patch('jiratui.widgets.screen.MainScreen.fetch_projects')
 @pytest.mark.asyncio
-async def test_select_and_display_work_item(
+async def test_select_and_display_work_item_without_cloud_use(
     search_projects_mock: AsyncMock,
     fetch_issue_types_mock: AsyncMock,
     fetch_statuses_mock: AsyncMock,
@@ -285,6 +289,7 @@ async def test_select_and_display_work_item(
     app.config.search_results_style_work_item_type = False
     app.config.search_results_per_page = 10
     app.config.show_issue_web_links = False
+    app.config.cloud = False
     async with app.run_test() as pilot:
         # GIVEN
         search_work_items_mock.return_value = WorkItemSearchResult(
@@ -328,6 +333,74 @@ async def test_select_and_display_work_item(
         assert focused_widget.assignee_selector.value == ''
         assert focused_widget.issue_resolution_field.value == 'this was done'
         assert focused_widget.issue_sprint_field.value == 'This Sprint'
+
+
+@patch.object(APIController, 'search_users_assignable_to_issue')
+@patch.object(APIController, 'get_issue')
+@patch('jiratui.widgets.screen.MainScreen._search_work_items')
+@patch('jiratui.widgets.screen.MainScreen.fetch_statuses')
+@patch('jiratui.widgets.screen.MainScreen.fetch_issue_types')
+@patch('jiratui.widgets.screen.MainScreen.fetch_projects')
+@pytest.mark.asyncio
+async def test_select_and_display_work_item_with_cloud_use(
+    search_projects_mock: AsyncMock,
+    fetch_issue_types_mock: AsyncMock,
+    fetch_statuses_mock: AsyncMock,
+    search_work_items_mock: AsyncMock,
+    get_issue_mock: AsyncMock,
+    search_users_assignable_to_issue_mock: AsyncMock,
+    jira_issues: list[JiraIssue],
+    app,
+):
+    app.config.search_results_truncate_work_item_summary = 10
+    app.config.search_results_style_work_item_status = False
+    app.config.search_results_style_work_item_type = False
+    app.config.search_results_per_page = 10
+    app.config.show_issue_web_links = False
+    app.config.cloud = True
+    async with app.run_test() as pilot:
+        # GIVEN
+        search_work_items_mock.return_value = WorkItemSearchResult(
+            total=2,
+            response=JiraIssueSearchResponse(
+                issues=jira_issues, next_page_token=None, is_last=None
+            ),
+        )
+        get_issue_mock.return_value = APIControllerResponse(
+            result=JiraIssueSearchResponse(issues=[jira_issues[1]])
+        )
+        main_screen = cast('MainScreen', app.screen)  # type:ignore[name-defined] # noqa: F821
+        # WHEN
+        await pilot.press('ctrl+r')
+        await pilot.press('down')
+        await pilot.press('enter')
+        await pilot.press('tab')
+        await pilot.press('right')
+        await pilot.press('tab')
+        # THEN
+        assert main_screen.search_results_table.focus()
+        assert main_screen.search_results_table.page == 1
+        search_work_items_mock.assert_called_once()
+        assert main_screen.search_results_table.search_results == JiraIssueSearchResponse(
+            issues=jira_issues, next_page_token=None, is_last=None
+        )
+        assert main_screen.search_results_table.current_work_item_key == 'key-2'
+        focused_widget = main_screen.focused
+        assert isinstance(focused_widget, IssueDetailsWidget)
+        assert focused_widget.issue_key_field.value == 'key-2'
+        assert focused_widget.issue_summary_field.value == 'qwerty'
+        assert focused_widget.project_id_field.value == '(P1) Project 1'
+        assert focused_widget.issue_created_date_field.value == '2025-10-11 00:00'
+        assert focused_widget.issue_created_date_field.value == '2025-10-11 00:00'
+        assert focused_widget.issue_due_date_field.value == '2025-10-12'
+        assert focused_widget.issue_resolution_date_field.value == '2025-10-11 00:00'
+        assert focused_widget.issue_parent_field.value == 'P2'
+        assert focused_widget.issue_type_field.value == 'Bug'
+        assert focused_widget.priority_selector.selection == '1'
+        assert focused_widget.reporter_selector.value == 'Bart Simpson'
+        assert focused_widget.assignee_selector.value == ''
+        assert focused_widget.issue_resolution_field.value == 'this was done'
+        assert focused_widget.issue_sprint_field is None
 
 
 @pytest.mark.parametrize('edit_metadata', [None, {'fields': {}}, {'fields': None}])
@@ -1070,8 +1143,9 @@ async def test_action_focus_widget(key: str, widget, app: JiraApp):
         assert isinstance(app.screen.focused, widget)
 
 
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
 @pytest.mark.asyncio
-async def test_clear_form(app: JiraApp):
+async def test_clear_form_with_support_for_sprint_selection(app: JiraApp):
     # GIVEN
     async with app.run_test() as pilot:
         details_widget = IssueDetailsWidget()
@@ -1089,7 +1163,6 @@ async def test_clear_form(app: JiraApp):
         assert details_widget.issue_key_field.value == ''
         assert details_widget.project_id_field.value == ''
         assert details_widget.issue_type_field.value == ''
-        assert details_widget.issue_sprint_field.value == ''
         assert details_widget.issue_status_selector.selection is None
         assert details_widget.assignee_selector.value == ''
         assert details_widget.assignee_selector.account_id is None
@@ -1103,6 +1176,20 @@ async def test_clear_form(app: JiraApp):
         assert details_widget.work_item_flag_widget.show is False
         assert len(details_widget.time_tracking_container.children) == 0
         assert len(details_widget.dynamic_fields_widgets_container.children) == 0
+
+
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=False))
+@pytest.mark.asyncio
+async def test_clear_form_without_support_for_sprint_selection(app: JiraApp):
+    # GIVEN
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        # WHEN
+        details_widget.clear_form = True
+        # THEN
+        assert details_widget.issue_sprint_field.value == ''
 
 
 @patch.object(APIController, 'update_issue')
@@ -1338,13 +1425,14 @@ async def test_watch_issue(jira_issue, app: JiraApp):
         assert result is None
 
 
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
 @patch.object(IssueDetailsWidget, '_setup_time_tracking')
 @patch.object(IssueDetailsWidget, '_add_dynamic_widgets')
 @patch.object(IssueDetailsWidget, '_determine_issue_flagged_status')
 @patch.object(IssueDetailsWidget, '_extract_editable_and_required_fields')
 @patch.object(APIController, 'get_project_statuses')
 @pytest.mark.asyncio
-async def test_watch_issue_with_valid_issue(
+async def test_watch_issue_with_valid_issue_with_support_for_sprint_selection(
     get_project_statuses_mock: AsyncMock,
     extract_editable_and_required_fields_mock: Mock,
     determine_issue_flagged_status_mock: Mock,
@@ -1390,7 +1478,7 @@ async def test_watch_issue_with_valid_issue(
         assert details_widget.issue_type_field.value == 'Bug'
         assert details_widget.issue_parent_field.value == 'P2'
         assert details_widget.issue_parent_field.update_enabled is True
-        assert details_widget.issue_sprint_field.value == 'This Sprint'
+        assert details_widget.issue_sprint_field is None
         assert details_widget.issue_summary_field.value == 'qwerty'
         assert details_widget.issue_summary_field.update_enabled is True
         assert details_widget.issue_due_date_field.value == '2025-10-12'
@@ -1511,8 +1599,162 @@ async def test_add_dynamic_widgets(
         assert isinstance(children[5], UsersAutoComplete)
 
 
+@patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
 @pytest.mark.asyncio
-async def test_static_widgets_css_classes(jira_issue, app: JiraApp):
+async def test_add_dynamic_widgets_with_support_for_sprint_selection(
+    create_dynamic_widgets_for_updating_work_item_mock: Mock,
+    fetch_sprints_in_project_mock: AsyncMock,
+    jira_issue: JiraIssue,
+    app: JiraApp,
+):
+    # GIVEN
+    app.config.enable_updating_additional_fields = True
+    app.config.update_additional_fields_ignore_ids = []
+    create_dynamic_widgets_for_updating_work_item_mock.return_value = [
+        SprintSelectionWidget(
+            mode=FieldMode.UPDATE,
+            field_id='customfield_10020',
+            jira_field_key='customfield_10020',
+            options=[],
+        ),
+    ]
+    fetch_sprints_in_project_mock.return_value = [
+        AgileSprint(id=2, name='Sprint 2', state=AgileSprintState.ACTIVE)
+    ]
+    jira_issue.sprint = None
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        # WHEN
+        await details_widget._add_dynamic_widgets(jira_issue)
+        # THEN
+        assert details_widget.dynamic_fields_widgets_container.is_empty is False
+        fetch_sprints_in_project_mock.assert_awaited_once_with(jira_issue.project.key)
+        children = list(details_widget.dynamic_fields_widgets_container.children)
+        assert isinstance(children[0], SprintSelectionWidget)
+        assert children[0]._options == [('', Select.NULL), ('(ACTIVE) Sprint 2', '2')]
+        assert children[0].selection is None
+        assert children[0].border_subtitle is None
+
+
+@patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
+@pytest.mark.asyncio
+async def test_add_dynamic_widgets_with_support_for_sprint_selection_with_current_sprint_selected(
+    create_dynamic_widgets_for_updating_work_item_mock: Mock,
+    fetch_sprints_in_project_mock: AsyncMock,
+    jira_issue: JiraIssue,
+    app: JiraApp,
+):
+    # GIVEN
+    app.config.enable_updating_additional_fields = True
+    app.config.update_additional_fields_ignore_ids = []
+    create_dynamic_widgets_for_updating_work_item_mock.return_value = [
+        SprintSelectionWidget(
+            mode=FieldMode.UPDATE,
+            field_id='customfield_10020',
+            jira_field_key='customfield_10020',
+            options=[],
+        ),
+    ]
+    fetch_sprints_in_project_mock.return_value = [
+        AgileSprint(id=2, name='Sprint 2', state=AgileSprintState.ACTIVE)
+    ]
+    jira_issue.sprint = JiraSprint(id='2', active=True, name='Sprint 2')
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        # WHEN
+        await details_widget._add_dynamic_widgets(jira_issue)
+        # THEN
+        assert details_widget.dynamic_fields_widgets_container.is_empty is False
+        fetch_sprints_in_project_mock.assert_awaited_once_with(jira_issue.project.key)
+        children = list(details_widget.dynamic_fields_widgets_container.children)
+        assert isinstance(children[0], SprintSelectionWidget)
+        assert children[0]._options == [('', Select.NULL), ('(ACTIVE) Sprint 2', '2')]
+        assert children[0].selection == '2'
+        assert children[0].border_subtitle is None
+
+
+@patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
+@pytest.mark.asyncio
+async def test_add_dynamic_widgets_with_support_for_sprint_selection_no_sprints_found(
+    create_dynamic_widgets_for_updating_work_item_mock: Mock,
+    fetch_sprints_in_project_mock: AsyncMock,
+    jira_issue: JiraIssue,
+    app: JiraApp,
+):
+    # GIVEN
+    app.config.enable_updating_additional_fields = True
+    app.config.update_additional_fields_ignore_ids = []
+    create_dynamic_widgets_for_updating_work_item_mock.return_value = [
+        SprintSelectionWidget(
+            mode=FieldMode.UPDATE,
+            field_id='customfield_10020',
+            jira_field_key='customfield_10020',
+            options=[],
+        ),
+    ]
+    fetch_sprints_in_project_mock.return_value = []
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        # WHEN
+        await details_widget._add_dynamic_widgets(jira_issue)
+        # THEN
+        assert details_widget.dynamic_fields_widgets_container.is_empty is False
+        fetch_sprints_in_project_mock.assert_awaited_once_with(jira_issue.project.key)
+        children = list(details_widget.dynamic_fields_widgets_container.children)
+        assert isinstance(children[0], SprintSelectionWidget)
+        assert children[0]._options == [('', Select.NULL)]
+
+
+@patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=False))
+@patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
+@pytest.mark.asyncio
+async def test_add_dynamic_widgets_without_support_for_sprint_selection(
+    create_dynamic_widgets_for_updating_work_item_mock: Mock,
+    fetch_sprints_in_project_mock: AsyncMock,
+    jira_issue: JiraIssue,
+    app: JiraApp,
+):
+    # GIVEN
+    app.config.enable_updating_additional_fields = True
+    app.config.update_additional_fields_ignore_ids = []
+    create_dynamic_widgets_for_updating_work_item_mock.return_value = [
+        MultiUserPickerWidget(
+            mode=FieldMode.UPDATE, field_id='approvers', jira_field_key='approvers'
+        )
+    ]
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        # WHEN
+        await details_widget._add_dynamic_widgets(jira_issue)
+        # THEN
+        assert details_widget.dynamic_fields_widgets_container.is_empty is False
+        fetch_sprints_in_project_mock.assert_not_called()
+        children = list(details_widget.dynamic_fields_widgets_container.children)
+        assert len(children) == 2
+        assert isinstance(children[0], MultiUserPickerWidget)
+        assert isinstance(children[1], MultiUserPickerAutoComplete)
+
+
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@pytest.mark.asyncio
+async def test_static_widgets_css_classes_with_support_for_sprint_selection(
+    jira_issue, app: JiraApp
+):
     # GIVEN
     async with app.run_test() as pilot:
         details_widget = IssueDetailsWidget()
@@ -1521,7 +1763,6 @@ async def test_static_widgets_css_classes(jira_issue, app: JiraApp):
         assert 'create-update-field-widget' in details_widget.issue_summary_field.classes
         assert 'create-update-field-widget' in details_widget.issue_key_field.classes
         assert 'work-item-key' in details_widget.issue_key_field.classes
-        assert 'create-update-field-widget' in details_widget.issue_sprint_field.classes
         assert 'create-update-field-widget' in details_widget.issue_parent_field.classes
         assert 'work-item-key' in details_widget.issue_parent_field.classes
         assert 'create-update-field-widget' in details_widget.project_id_field.classes
@@ -1533,6 +1774,17 @@ async def test_static_widgets_css_classes(jira_issue, app: JiraApp):
         assert 'create-update-field-widget' in details_widget.issue_resolution_date_field.classes
         assert 'input-date' in details_widget.issue_resolution_date_field.classes
         assert 'create-update-field-widget' in details_widget.issue_resolution_field.classes
+
+
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=False))
+@pytest.mark.asyncio
+async def test_static_widgets_css_classes(jira_issue, app: JiraApp):
+    # GIVEN
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        assert 'create-update-field-widget' in details_widget.issue_sprint_field.classes
 
 
 @patch.object(IssueDetailsWidget, 'issue')
@@ -1631,3 +1883,177 @@ async def test_action_view_worklog_no_issue_set(app: JiraApp):
         details_widget.action_view_worklog()
         # THEN
         assert not isinstance(app.screen, WorkItemWorkLogScreen)
+
+
+@pytest.mark.asyncio
+async def test_fetch_sprints_in_project_without_project_key(app: JiraApp):
+    # GIVEN
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        assert details_widget.issue is None
+        # WHEN
+        sprints = await details_widget._fetch_sprints_in_project('')
+        # THEN
+        assert sprints is None
+
+
+@patch.object(IssueDetailsWidget, '_get_sprints_from_application_session')
+@pytest.mark.asyncio
+async def test_fetch_sprints_in_project_with_sprints_in_session(
+    get_sprints_from_application_session_mock: Mock, app: JiraApp
+):
+    # GIVEN
+    get_sprints_from_application_session_mock.return_value = {
+        'P1': [AgileSprint(id=1, name='Sprint 1', state=AgileSprintState.ACTIVE)]
+    }
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        assert details_widget.issue is None
+        # WHEN
+        sprints = await details_widget._fetch_sprints_in_project('P1')
+        # THEN
+        assert sprints == [AgileSprint(id=1, name='Sprint 1', state=AgileSprintState.ACTIVE)]
+
+
+@pytest.mark.parametrize(
+    'get_project_sprints_response',
+    [
+        APIControllerResponse(success=False),
+        APIControllerResponse(result=None),
+    ],
+)
+@patch.object(APIController, 'get_project_sprints')
+@patch.object(IssueDetailsWidget, '_get_sprints_from_application_session')
+@pytest.mark.asyncio
+async def test_fetch_sprints_in_project_without_sprints_in_session_fetching_fails(
+    get_sprints_from_application_session_mock: Mock,
+    get_project_sprints_mock: AsyncMock,
+    get_project_sprints_response,
+    app: JiraApp,
+):
+    # GIVEN
+    get_sprints_from_application_session_mock.return_value = {
+        'P2': [AgileSprint(id=1, name='Sprint 1', state=AgileSprintState.ACTIVE)]
+    }
+    get_project_sprints_mock.return_value = get_project_sprints_response
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        assert details_widget.issue is None
+        # WHEN
+        sprints = await details_widget._fetch_sprints_in_project('P1')
+        # THEN
+        get_sprints_from_application_session_mock.assert_called_once()
+        get_project_sprints_mock.assert_called_once_with('P1')
+        assert sprints is None
+
+
+@patch.object(APIController, 'get_project_sprints')
+@patch.object(IssueDetailsWidget, '_get_sprints_from_application_session')
+@pytest.mark.asyncio
+async def test_fetch_sprints_in_project_without_sprints_in_session_fetching_succeeds(
+    get_sprints_from_application_session_mock: Mock,
+    get_project_sprints_mock: AsyncMock,
+    app: JiraApp,
+):
+    # GIVEN
+    get_sprints_from_application_session_mock.return_value = {}
+    get_project_sprints_mock.return_value = APIControllerResponse(
+        result=[
+            AgileSprint(id=2, name='Sprint 2', state=AgileSprintState.ACTIVE),
+            AgileSprint(id=3, name='Sprint 3', state=AgileSprintState.FUTURE),
+        ]
+    )
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        assert details_widget.issue is None
+        # WHEN
+        sprints = await details_widget._fetch_sprints_in_project('P1')
+        # THEN
+        get_sprints_from_application_session_mock.assert_called_once()
+        get_project_sprints_mock.assert_called_once_with('P1')
+        assert sprints == [
+            AgileSprint(id=2, name='Sprint 2', state=AgileSprintState.ACTIVE),
+            AgileSprint(id=3, name='Sprint 3', state=AgileSprintState.FUTURE),
+        ]
+
+
+@patch.object(APIController, 'get_project_sprints')
+@patch.object(IssueDetailsWidget, '_get_sprints_from_application_session')
+@pytest.mark.asyncio
+async def test_fetch_sprints_in_project_with_sprints_in_session_fetching_succeeds(
+    get_sprints_from_application_session_mock: Mock,
+    get_project_sprints_mock: AsyncMock,
+    app: JiraApp,
+):
+    # GIVEN
+    get_sprints_from_application_session_mock.return_value = {
+        'P2': [AgileSprint(id=1, name='Sprint 1', state=AgileSprintState.ACTIVE)]
+    }
+    get_project_sprints_mock.return_value = APIControllerResponse(
+        result=[
+            AgileSprint(id=2, name='Sprint 2', state=AgileSprintState.ACTIVE),
+            AgileSprint(id=3, name='Sprint 3', state=AgileSprintState.FUTURE),
+        ]
+    )
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        assert details_widget.issue is None
+        # WHEN
+        sprints = await details_widget._fetch_sprints_in_project('P1')
+        # THEN
+        get_sprints_from_application_session_mock.assert_called_once()
+        get_project_sprints_mock.assert_called_once_with('P1')
+        assert sprints == [
+            AgileSprint(id=2, name='Sprint 2', state=AgileSprintState.ACTIVE),
+            AgileSprint(id=3, name='Sprint 3', state=AgileSprintState.FUTURE),
+        ]
+
+
+@pytest.mark.parametrize(
+    'sprint, expected_sprint_widget_value',
+    [
+        (JiraSprint(id='1', name='Sprint 1', active=True), 'Sprint 1'),
+        (None, ''),
+    ],
+)
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=False))
+@pytest.mark.asyncio
+async def test_set_issue_without_support_for_sprint_selection(
+    sprint, expected_sprint_widget_value, jira_issue: JiraIssue, app: JiraApp
+):
+    # GIVEN
+    jira_issue.sprint = sprint
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        # WHEN
+        details_widget.issue = jira_issue
+        # THEN
+        assert details_widget.issue_sprint_field.value == expected_sprint_widget_value
+        assert isinstance(details_widget.issue_sprint_field, IssueSprintField)
+
+
+@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@pytest.mark.asyncio
+async def test_set_issue_with_support_for_sprint_selection(jira_issue: JiraIssue, app: JiraApp):
+    # GIVEN
+    jira_issue.sprint = JiraSprint(id='1', name='Sprint 1', active=True)
+    async with app.run_test() as pilot:
+        details_widget = IssueDetailsWidget()
+        await app.mount(details_widget)
+        await pilot.pause()
+        # WHEN
+        details_widget.issue = jira_issue
+        # THEN
+        assert details_widget.issue_sprint_field is None

--- a/src/jiratui/widgets/work_item_details/tests/test_widgets_factory.py
+++ b/src/jiratui/widgets/work_item_details/tests/test_widgets_factory.py
@@ -1,7 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 
 from jiratui.app import JiraApp
-from jiratui.models import IssueStatus, IssueType, JiraIssue
+from jiratui.models import IssueStatus, IssueType, JiraIssue, JiraSprint
 from jiratui.widgets.commons.widgets import (
     DateInputWidget,
     DateTimeInputWidget,
@@ -9,6 +11,7 @@ from jiratui.widgets.commons.widgets import (
     MultiSelectWidget,
     NumericInputWidget,
     SelectionWidget,
+    SprintSelectionWidget,
     TextInputWidget,
     URLWidget,
 )
@@ -1184,3 +1187,118 @@ async def test_create_dynamic_widgets_field_date_changing_value(
         widgets[0].value = '2025-12-30'
         assert widgets[0].value_has_changed is True
         assert widgets[0].original_value == '2025-12-31'
+
+
+@patch('jiratui.widgets.work_item_details.factory._uses_cloud_api')
+@pytest.mark.asyncio
+async def test_create_dynamic_widgets_custom_field_sprint_selection_using_cloud_api_without_current_sprint(
+    uses_cloud_api_mock,
+    work_item: JiraIssue,
+    app: JiraApp,
+):
+    # GIVEN
+    uses_cloud_api_mock.return_value = True
+    work_item.edit_meta['fields'] = {
+        'customfield_10020': {
+            'required': False,
+            'schema': {
+                'type': 'array',
+                'items': 'json',
+                'custom': 'com.pyxis.greenhopper.jira:gh-sprint',
+                'customId': 10020,
+            },
+            'name': 'Sprint',
+            'key': 'customfield_10020',
+            'hasDefaultValue': False,
+            'operations': ['set'],
+            'fieldId': 'customfield_10020',
+        }
+    }
+    work_item.sprint = None
+    # WHEN
+    async with app.run_test():
+        widgets = create_dynamic_widgets_for_updating_work_item(work_item)
+        # THEN
+        assert len(widgets) == 1
+        assert isinstance(widgets[0], SprintSelectionWidget)
+        widget: SprintSelectionWidget = widgets[0]
+        assert widget.id == 'customfield_10020'
+        assert widget.original_value is None
+        assert widget.disabled is False
+        assert widget.get_value_for_update() is None
+        assert widget.selection is None
+        assert widget.border_subtitle is None
+
+
+@patch('jiratui.widgets.work_item_details.factory._uses_cloud_api')
+@pytest.mark.asyncio
+async def test_create_dynamic_widgets_custom_field_sprint_selection_using_cloud_api_with_current_sprint(
+    uses_cloud_api_mock,
+    work_item: JiraIssue,
+    app: JiraApp,
+):
+    # GIVEN
+    uses_cloud_api_mock.return_value = True
+    work_item.edit_meta['fields'] = {
+        'customfield_10020': {
+            'required': False,
+            'schema': {
+                'type': 'array',
+                'items': 'json',
+                'custom': 'com.pyxis.greenhopper.jira:gh-sprint',
+                'customId': 10020,
+            },
+            'name': 'Sprint',
+            'key': 'customfield_10020',
+            'hasDefaultValue': False,
+            'operations': ['set'],
+            'fieldId': 'customfield_10020',
+        }
+    }
+    work_item.sprint = JiraSprint(id='1', active=True, name='Sprint 1')
+    # WHEN
+    async with app.run_test():
+        widgets = create_dynamic_widgets_for_updating_work_item(work_item)
+        # THEN
+        assert len(widgets) == 1
+        assert isinstance(widgets[0], SprintSelectionWidget)
+        widget: SprintSelectionWidget = widgets[0]
+        assert widget.id == 'customfield_10020'
+        assert widget.original_value == '1'
+        assert widget.disabled is False
+        assert widget.get_value_for_update() == 1
+        assert widget.selection == '1'
+        assert widget.border_subtitle is None
+
+
+@patch('jiratui.widgets.work_item_details.factory._uses_cloud_api')
+@pytest.mark.asyncio
+async def test_create_dynamic_widgets_custom_field_sprint_selection_without_using_cloud_api(
+    uses_cloud_api_mock,
+    work_item: JiraIssue,
+    app: JiraApp,
+):
+    # GIVEN
+    uses_cloud_api_mock.return_value = False
+    work_item.edit_meta['fields'] = {
+        'customfield_10020': {
+            'required': False,
+            'schema': {
+                'type': 'array',
+                'items': 'json',
+                'custom': 'com.pyxis.greenhopper.jira:gh-sprint',
+                'customId': 10020,
+            },
+            'name': 'Sprint',
+            'key': 'customfield_10020',
+            'hasDefaultValue': False,
+            'operations': ['set'],
+            'fieldId': 'customfield_10020',
+        }
+    }
+
+    # WHEN
+    async with app.run_test():
+        widgets = create_dynamic_widgets_for_updating_work_item(work_item)
+        # THEN
+        assert len(widgets) == 0


### PR DESCRIPTION
This PR adds support for updating the sprint field of a work item.

This feature is *only** supported when the application connects to the Jira Cloud Platform REST API. When the application connects to the Jira on-premises instance the application will still display the item's sprint (if any) but it won't allow the user to update it.

To fetch the list of active/future sprints the application uses the Jira Software Cloud API.

<img width="738" height="695" alt="Screenshot 2026-07-19 at 17 05 41" src="https://github.com/user-attachments/assets/e55d1a44-ed2d-426f-b807-c33189b3c560" />
