### PR TITLE
fix: parse allowedValues shapes without id/name keys

### DIFF
--- a/src/jiratui/tests/test_factory_utils.py
+++ b/src/jiratui/tests/test_factory_utils.py
@@ -1,0 +1,44 @@
+import pytest
+
+from jiratui.widgets.commons.factory_utils import (
+    AllowedValuesParser,
+    FieldMetadata,
+    FieldMode,
+    WidgetBuilder,
+)
+
+
+@pytest.mark.parametrize(
+    'allowed_values,expected',
+    [
+        ([{'id': '10001', 'name': 'Bug'}], [('Bug', '10001')]),
+        ([{'id': '3', 'value': 'High'}], [('High', '3')]),
+        ([{'languageCode': 'en', 'displayName': 'English'}], [('English', 'en')]),
+    ],
+)
+def test_parse_options_supports_alternative_shapes(allowed_values, expected):
+    assert AllowedValuesParser.parse_options(allowed_values) == expected
+
+
+def test_build_selection_for_service_desk_language_field():
+    """A `sd-request-lang` field must not crash the details worker. See issue #311."""
+
+    allowed_values = [{'languageCode': 'en', 'displayName': 'English'}]
+    metadata = FieldMetadata(
+        {
+            'fieldId': 'customfield_10053',
+            'key': 'customfield_10053',
+            'name': 'Request language',
+            'schema': {'type': 'sd-request-lang'},
+            'operations': [],
+        }
+    )
+
+    widget = WidgetBuilder.build_selection(
+        mode=FieldMode.UPDATE,
+        metadata=metadata,
+        options=AllowedValuesParser.parse_options(allowed_values),
+        current_value='en',
+    )
+
+    assert widget.value == 'en'

--- a/src/jiratui/widgets/commons/factory_utils.py
+++ b/src/jiratui/widgets/commons/factory_utils.py
@@ -135,9 +135,10 @@ class AllowedValuesParser:
         if not allowed_values:
             return options
         for value in allowed_values:
-            # Try 'name' first, fall back to 'value'
-            display_value = value.get('name') or value.get('value', '')
-            value_id = value.get('id', '')
+            # Try 'name' first, fall back to 'value' and then to 'displayName'
+            display_value = value.get('name') or value.get('value') or value.get('displayName', '')
+            # Try 'id' first, fall back to 'languageCode' used by service-desk language fields
+            value_id = value.get('id') or value.get('languageCode', '')
             if display_value and value_id:
                 options.append((display_value, value_id))
         return options


### PR DESCRIPTION
Closes #311

A JSM "Request language" field (`sd-request-lang`) exposes its `allowedValues` as `{languageCode, displayName}`, a shape `AllowedValuesParser.parse_options` did not recognise, so it returned no options and `build_selection` then set a value Textual rejected — crashing the details worker with `InvalidSelectValueError: Illegal select value 'en'`.

This extends the existing fallback chains to also accept `displayName` as the label and `languageCode` as the value id. Added `src/jiratui/tests/test_factory_utils.py`, which reproduces the exact error without the fix and passes with it.