### PR TITLE
Add user mentions when submitting comments (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for mentioning users in comments. Typing `@` (or pressing `ctrl+@`) while writing a comment on
+Jira Cloud (API v3) opens a user search; selecting a user inserts an `@[Name](accountId)` token that is
+submitted as an ADF `mention` node. Resolves [#125](https://github.com/whyisdifficult/jiratui/issues/125).
 - Add support for sessions using `ApplicationSession`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/276
 - Add support for remembering the last-used directory when uploading files. This uses `ApplicationSession`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/276
 - Add support for updating worklog entries. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/282

--- a/docs/users/usage/index.md
+++ b/docs/users/usage/index.md
@@ -667,6 +667,18 @@ This image shows a list of comments associated to the selected work item.
 This contains the comments associated to the selected work item. Comments can be deleted by focusing on them and then
 pressing `d`. Comments can be added by pressing `n`.
 
+##### Mentioning users in a comment
+
+While writing a comment you can mention another Jira user. Type `@` (at the start of a word) or press `ctrl+@`
+to open the user search, type part of a name or email, and select a user. The mention is inserted as a
+`@[Display Name](accountId)` token and submitted to Jira as a proper mention, so the mentioned user is
+notified. Press `Esc` to cancel the search (your `@` is kept as normal text).
+
+```{note}
+Mentions are available on Jira Cloud using API v3 (the default), where comments are submitted using the
+Atlassian Document Format (ADF). On Jira Data Center or when using API v2 the `@` search is not shown.
+```
+
 #### Related Work Items
 
 ```{figure} /_static/assets/images/related.png

--- a/src/jiratui/api_controller/controller.py
+++ b/src/jiratui/api_controller/controller.py
@@ -65,6 +65,7 @@ from jiratui.models import (
     WorkItemsSearchOrderBy,
 )
 from jiratui.utils.adf import convert_markdown_to_adf
+from jiratui.utils.mentions import expand_mention_tokens
 
 
 @dataclass
@@ -1923,7 +1924,7 @@ class APIController:
 
     def _convert_comment_message_to_adf(self, message: str) -> dict:
         try:
-            return convert_markdown_to_adf(message)
+            return convert_markdown_to_adf(expand_mention_tokens(message))
         except Exception as e:
             self.logger.warning('Failed to convert Markdown to ADF: %s', str(e))
             return {

--- a/src/jiratui/api_controller/tests/test_controller.py
+++ b/src/jiratui/api_controller/tests/test_controller.py
@@ -5005,3 +5005,37 @@ async def test_issue_picker_with_error(issue_picker_mock: Mock, jira_api_control
         show_sub_tasks=True,
         current_issue_key=None,
     )
+
+
+def test_convert_comment_message_to_adf_expands_mention_token(
+    jira_api_controller: APIController,
+):
+    # GIVEN a comment containing a picker-generated mention token
+    message = 'Please review @[Homer Simpson](557058:abc-123)'
+    # WHEN
+    adf = jira_api_controller._convert_comment_message_to_adf(message)
+    # THEN the token becomes a proper ADF mention node
+    nodes = [
+        node
+        for paragraph in adf['content']
+        for node in paragraph.get('content', [])
+        if node.get('type') == 'mention'
+    ]
+    assert len(nodes) == 1
+    assert nodes[0]['attrs']['id'] == '557058:abc-123'
+    assert nodes[0]['attrs']['text'] == '@Homer Simpson'
+
+
+def test_convert_comment_message_to_adf_without_mentions(
+    jira_api_controller: APIController,
+):
+    # GIVEN a plain comment (an '@' that is not a token stays literal text)
+    adf = jira_api_controller._convert_comment_message_to_adf('ping user@example.com')
+    # THEN there are no mention nodes
+    nodes = [
+        node
+        for paragraph in adf['content']
+        for node in paragraph.get('content', [])
+        if node.get('type') == 'mention'
+    ]
+    assert nodes == []

--- a/src/jiratui/utils/mentions.py
+++ b/src/jiratui/utils/mentions.py
@@ -1,0 +1,86 @@
+"""Helpers for embedding Jira user mentions in comment Markdown.
+
+Jira Cloud represents an ``@`` mention as an ADF ``mention`` node that carries the mentioned user's
+``accountId``. The bundled ``marklas`` library already converts an HTML-like span into such a node during the
+Markdown -> ADF conversion. To keep the comment editor legible, the "Add Comment" screen inserts a readable,
+Markdown-link-style *token* rather than the raw span, and those tokens are expanded to spans right before the
+Markdown is converted to ADF.
+
+**Token format** (picker-generated; not intended for hand authoring)::
+
+    @[Display Name](accountId)
+
+is expanded to the ``marklas`` mention span::
+
+    <span adf="mention" params='{"id":"accountId"}'>@Display Name</span>
+
+which ``marklas.to_adf`` turns into::
+
+    {'type': 'mention', 'attrs': {'id': 'accountId', 'text': '@Display Name'}}
+
+Tokens that do not match the expected grammar are left untouched and are therefore submitted as literal text,
+so a malformed or hand-edited token can never break comment submission.
+"""
+
+import json
+import re
+
+MENTION_TOKEN_PATTERN = re.compile(r'@\[(?P<name>[^\]]+)\]\((?P<account_id>[^)]+)\)')
+"""Matches a picker-generated mention token, e.g. ``@[Homer Simpson](557058:abc-123)``."""
+
+
+def build_mention_token(display_name: str, account_id: str) -> str:
+    """Builds a mention token to insert into the comment editor.
+
+    Characters that would break the token grammar (``[`` / ``]`` in the display name and ``(`` / ``)`` in the
+    account id) are removed. These are exceedingly rare in Jira identities.
+
+    Args:
+        display_name: the display name of the mentioned user, e.g. ``Homer Simpson``.
+        account_id: the Jira ``accountId`` of the mentioned user.
+
+    Returns:
+        A token of the form ``@[Display Name](accountId)``.
+    """
+
+    safe_name = re.sub(r'[\[\]]', '', display_name).strip()
+    safe_account_id = re.sub(r'[()]', '', account_id).strip()
+    return f'@[{safe_name}]({safe_account_id})'
+
+
+def render_mention_markup(display_name: str, account_id: str) -> str:
+    """Builds the ``marklas`` mention span for a single user.
+
+    Args:
+        display_name: the display name of the mentioned user.
+        account_id: the Jira ``accountId`` of the mentioned user.
+
+    Returns:
+        A ``marklas``-compatible ``<span adf="mention" ...>`` string that ``marklas.to_adf`` converts into an
+        ADF ``mention`` node.
+    """
+
+    params = json.dumps({'id': account_id}, separators=(',', ':'), ensure_ascii=False)
+    return f'<span adf="mention" params=\'{params}\'>@{display_name}</span>'
+
+
+def expand_mention_tokens(markdown: str) -> str:
+    """Replaces mention tokens in a Markdown string with ``marklas`` mention spans.
+
+    Tokens that do not match :data:`MENTION_TOKEN_PATTERN` are left untouched and will be submitted as literal
+    text.
+
+    Args:
+        markdown: the comment text in Markdown, possibly containing ``@[Name](accountId)`` tokens.
+
+    Returns:
+        The Markdown with every recognised mention token expanded to a ``marklas`` mention span. If the input
+        contains no tokens it is returned unchanged.
+    """
+
+    if not markdown or '@[' not in markdown:
+        return markdown
+    return MENTION_TOKEN_PATTERN.sub(
+        lambda match: render_mention_markup(match['name'], match['account_id']),
+        markdown,
+    )

--- a/src/jiratui/utils/tests/test_mentions.py
+++ b/src/jiratui/utils/tests/test_mentions.py
@@ -1,0 +1,90 @@
+from jiratui.utils.adf import convert_markdown_to_adf
+from jiratui.utils.mentions import (
+    build_mention_token,
+    expand_mention_tokens,
+    render_mention_markup,
+)
+
+
+def test_build_mention_token():
+    assert (
+        build_mention_token('Homer Simpson', '557058:abc-123') == '@[Homer Simpson](557058:abc-123)'
+    )
+
+
+def test_build_mention_token_sanitizes_brackets_in_name():
+    # square brackets would break the token grammar and are stripped
+    assert build_mention_token('Bart [the] Brat', 'id-1') == '@[Bart the Brat](id-1)'
+
+
+def test_build_mention_token_sanitizes_parentheses_in_account_id():
+    assert build_mention_token('Lisa', 'id(9)') == '@[Lisa](id9)'
+
+
+def test_render_mention_markup():
+    assert (
+        render_mention_markup('Homer Simpson', '557058:abc-123')
+        == '<span adf="mention" params=\'{"id":"557058:abc-123"}\'>@Homer Simpson</span>'
+    )
+
+
+def test_expand_mention_tokens_without_tokens_returns_input_unchanged():
+    text = 'Just a regular comment with an email user@example.com and a [link](http://x)'
+    assert expand_mention_tokens(text) == text
+
+
+def test_expand_mention_tokens_empty_string():
+    assert expand_mention_tokens('') == ''
+
+
+def test_expand_mention_tokens_single_token():
+    result = expand_mention_tokens('Hey @[Homer Simpson](abc-123) please review')
+    assert result == (
+        'Hey <span adf="mention" params=\'{"id":"abc-123"}\'>@Homer Simpson</span> please review'
+    )
+
+
+def test_expand_mention_tokens_multiple_tokens():
+    result = expand_mention_tokens('@[Homer](a) and @[Bart](b)')
+    assert result == (
+        '<span adf="mention" params=\'{"id":"a"}\'>@Homer</span> and '
+        '<span adf="mention" params=\'{"id":"b"}\'>@Bart</span>'
+    )
+
+
+def test_expand_mention_tokens_inside_markdown_formatting():
+    # a token wrapped in bold markdown must still expand
+    result = expand_mention_tokens('**@[Homer](a)**')
+    assert result == '**<span adf="mention" params=\'{"id":"a"}\'>@Homer</span>**'
+
+
+def test_expand_mention_tokens_unicode_name():
+    result = expand_mention_tokens('@[Homère Simpson](id-é)')
+    assert '>@Homère Simpson</span>' in result
+    assert '"id":"id-é"' in result
+
+
+def test_mention_token_round_trips_to_adf_mention_node():
+    markdown = expand_mention_tokens('Hey @[Homer Simpson](557058:abc-123)!')
+    adf = convert_markdown_to_adf(markdown)
+    nodes = [
+        node
+        for paragraph in adf['content']
+        for node in paragraph.get('content', [])
+        if node.get('type') == 'mention'
+    ]
+    assert len(nodes) == 1
+    assert nodes[0]['attrs']['id'] == '557058:abc-123'
+    assert nodes[0]['attrs']['text'] == '@Homer Simpson'
+
+
+def test_multiple_mention_tokens_round_trip_to_adf():
+    markdown = expand_mention_tokens('@[Homer](a-1) ping @[Bart](b-2)')
+    adf = convert_markdown_to_adf(markdown)
+    nodes = [
+        node
+        for paragraph in adf['content']
+        for node in paragraph.get('content', [])
+        if node.get('type') == 'mention'
+    ]
+    assert [node['attrs']['id'] for node in nodes] == ['a-1', 'b-2']

--- a/src/jiratui/widgets/comments/add.py
+++ b/src/jiratui/widgets/comments/add.py
@@ -1,9 +1,111 @@
+"""Widgets for the modal screen that lets a user write and submit a comment.
+
+The screen also provides an ``@`` mention picker: typing ``@`` at a word boundary (or the ``ctrl+@`` binding)
+opens a small overlay that live-searches Jira users and inserts a mention *token* (``@[Name](accountId)``) at
+the cursor. Tokens are expanded to ADF ``mention`` nodes on submit by
+[expand_mention_tokens](#jiratui.utils.mentions.expand_mention_tokens); see
+[proposals/0001](https://github.com/whyisdifficult/jiratui/issues/125).
+"""
+
+from typing import cast
+
 from rich.text import Text
-from textual import on
+from textual import events, on
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import ItemGrid, Vertical
+from textual.message import Message
 from textual.screen import Screen
-from textual.widgets import Button, Static, TextArea
+from textual.widgets import Button, Label, Static, TextArea
+from textual_autocomplete import TargetState
+
+from jiratui.api_controller.controller import APIControllerResponse
+from jiratui.utils.mentions import build_mention_token
+from jiratui.widgets.commons.users import JiraUserInput, UsersAutoComplete
+
+Location = tuple[int, int]
+
+
+class CommentTextArea(TextArea):
+    """A Markdown `TextArea` that requests the mention picker when the user types ``@``.
+
+    The ``@`` character is still inserted as normal text; a [MentionRequested](#jiratui.widgets.comments.add.CommentTextArea.MentionRequested)
+    message is posted alongside it so the screen can open the mention picker. The message is only posted when
+    ``@`` is typed at a *word boundary* (start of line or after whitespace) and there is no active selection,
+    so email addresses such as ``user@example.com`` never trigger it.
+    """
+
+    class MentionRequested(Message):
+        """Posted when the user types ``@`` at a word boundary.
+
+        Attributes:
+            location: the (row, column) location of the ``@`` that triggered the request.
+        """
+
+        def __init__(self, location: Location) -> None:
+            self.location = location
+            super().__init__()
+
+    async def _on_key(self, event: events.Key) -> None:
+        is_mention_trigger = (
+            event.character == '@'
+            and not self.read_only
+            and self.selection.start == self.selection.end
+            and self._preceding_char_is_boundary()
+        )
+        await super()._on_key(event)
+        if is_mention_trigger:
+            row, column = self.cursor_location
+            self.post_message(self.MentionRequested(location=(row, max(column - 1, 0))))
+
+    def _preceding_char_is_boundary(self) -> bool:
+        row, column = self.cursor_location
+        if column == 0:
+            return True
+        try:
+            return self.document[row][column - 1].isspace()
+        except IndexError:
+            return True
+
+
+class MentionAutoComplete(UsersAutoComplete):
+    """A [UsersAutoComplete](#jiratui.widgets.commons.users.UsersAutoComplete) that announces the picked user.
+
+    The base class stores the selected user's account id on the target input but does not emit a message; this
+    subclass posts a [UserSelected](#jiratui.widgets.comments.add.MentionAutoComplete.UserSelected) message so
+    the screen can build and insert the mention token.
+    """
+
+    class UserSelected(Message):
+        """Posted when a user is chosen from the mention autocomplete dropdown."""
+
+        def __init__(self, account_id: str, display_name: str) -> None:
+            self.account_id = account_id
+            self.display_name = display_name
+            super().__init__()
+
+    def apply_completion(self, value: str, state: TargetState) -> None:
+        super().apply_completion(value, state)
+        account_id = getattr(self.target, 'account_id', None)
+        display_name = (self.target.value or '').split('|', 1)[0].strip()
+        if account_id and display_name:
+            self.post_message(self.UserSelected(account_id=account_id, display_name=display_name))
+
+
+class MentionOverlay(Vertical):
+    """The inline overlay that hosts the mention search input.
+
+    It is an ancestor of the search `Input`, so its ``escape`` binding takes precedence over the screen's
+    ``escape`` binding and cancels the picker instead of closing the whole screen.
+    """
+
+    BINDINGS = [Binding('escape', 'cancel', 'Cancel', show=False)]
+
+    class Cancelled(Message):
+        """Posted when the user cancels the mention picker."""
+
+    def action_cancel(self) -> None:
+        self.post_message(self.Cancelled())
 
 
 class AddCommentScreen(Screen[str]):
@@ -18,12 +120,17 @@ class AddCommentScreen(Screen[str]):
     - [Architecture](#architecture-work-item-comments-classes)
     """
 
-    BINDINGS = [('escape', 'app.pop_screen', 'Close')]
+    BINDINGS = [
+        ('escape', 'app.pop_screen', 'Close'),
+        Binding('ctrl+@', 'open_mention_picker', 'Mention', show=False),
+    ]
 
     def __init__(self, work_item_key: str | None = None):
         super().__init__()
         self.__work_item_key = work_item_key
         self.title = f'Add comment to the work item {self.__work_item_key}'
+        self._mention_overlay_open: bool = False
+        self._mention_trigger_location: Location | None = None
 
     @property
     def comment_textarea(self) -> TextArea:
@@ -43,7 +150,7 @@ class AddCommentScreen(Screen[str]):
                 ),
                 classes='tip',
             )
-            textarea = TextArea.code_editor(
+            textarea = CommentTextArea.code_editor(
                 '', language='markdown', show_line_numbers=False, compact=True
             )
             textarea.border_title = 'Comment'
@@ -65,3 +172,85 @@ class AddCommentScreen(Screen[str]):
     @on(Button.Pressed, '#add-comment-button-quit')
     def handle_cancel(self) -> None:
         self.dismiss('')
+
+    # -- mention picker ---------------------------------------------------------------------------------------
+
+    def _mentions_enabled(self) -> bool:
+        """Mentions are only supported on Jira Cloud with API v3 (where comments are submitted as ADF)."""
+        try:
+            return bool(cast('JiraApp', self.app).api._adf_support_enabled())  # type:ignore[name-defined] # noqa: F821
+        except Exception:
+            return False
+
+    async def _search_users_for_mention(self, query: str) -> APIControllerResponse:
+        api = cast('JiraApp', self.app).api  # type:ignore[name-defined] # noqa: F821
+        if self.__work_item_key:
+            return await api.search_users_assignable_to_issue(
+                issue_key=self.__work_item_key, query=query
+            )
+        return await api.search_users(email_or_name=query)
+
+    @on(CommentTextArea.MentionRequested)
+    async def _on_mention_requested(self, message: CommentTextArea.MentionRequested) -> None:
+        message.stop()
+        await self._open_mention_picker(trigger_location=message.location)
+
+    def action_open_mention_picker(self) -> None:
+        self.run_worker(self._open_mention_picker())
+
+    async def _open_mention_picker(self, trigger_location: Location | None = None) -> None:
+        if self._mention_overlay_open or not self._mentions_enabled():
+            return
+        self._mention_overlay_open = True
+        self._mention_trigger_location = trigger_location
+        user_input = JiraUserInput(id='mention-user-input', border_title='Mention a user')
+        overlay = MentionOverlay(
+            Label('Search a user to mention. Enter selects, Esc cancels.', classes='tip'),
+            user_input,
+            id='mention-overlay',
+        )
+        await self.mount(overlay)
+        await self.mount(
+            MentionAutoComplete(
+                user_input,
+                cast('JiraApp', self.app).api,  # type:ignore[name-defined] # noqa: F821
+                id='mention-autocomplete',
+                user_search_function=self._search_users_for_mention,
+            )
+        )
+        user_input.focus()
+
+    @on(MentionAutoComplete.UserSelected)
+    async def _on_mention_user_selected(self, message: MentionAutoComplete.UserSelected) -> None:
+        message.stop()
+        token = build_mention_token(message.display_name, message.account_id)
+        textarea = self.comment_textarea
+        location = self._mention_trigger_location
+        if location is not None and self._char_at_is_trigger(location):
+            end = (location[0], location[1] + 1)
+            textarea.replace(token, location, end)
+            textarea.move_cursor((location[0], location[1] + len(token)))
+        else:
+            textarea.insert(token)
+        await self._close_mention_picker()
+        textarea.focus()
+
+    @on(MentionOverlay.Cancelled)
+    async def _on_mention_cancelled(self, message: MentionOverlay.Cancelled) -> None:
+        message.stop()
+        await self._close_mention_picker()
+        self.comment_textarea.focus()
+
+    def _char_at_is_trigger(self, location: Location) -> bool:
+        row, column = location
+        try:
+            return self.comment_textarea.document[row][column] == '@'
+        except IndexError:
+            return False
+
+    async def _close_mention_picker(self) -> None:
+        self._mention_overlay_open = False
+        self._mention_trigger_location = None
+        for selector in ('#mention-autocomplete', '#mention-overlay'):
+            for widget in list(self.query(selector)):
+                await widget.remove()

--- a/src/jiratui/widgets/comments/tests/test_comments.py
+++ b/src/jiratui/widgets/comments/tests/test_comments.py
@@ -22,6 +22,97 @@ def mock_configuration():
 
 
 @pytest.mark.asyncio
+async def test_typing_at_opens_mention_overlay(app):
+    async with app.run_test() as pilot:
+        # GIVEN the add-comment screen (app fixture is Cloud + API v3, so mentions are enabled)
+        screen = AddCommentScreen('WI-1')
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN the user types '@' at the start of the comment (a word boundary)
+        await pilot.press('at')
+        await pilot.pause()
+        # THEN the mention overlay opens
+        assert screen._mention_overlay_open is True
+        assert len(screen.query('#mention-overlay')) == 1
+        assert screen.comment_textarea.text == '@'
+
+
+@pytest.mark.asyncio
+async def test_typing_at_after_word_does_not_open_overlay(app):
+    async with app.run_test() as pilot:
+        screen = AddCommentScreen('WI-1')
+        await app.push_screen(screen)
+        await pilot.pause()
+        # WHEN the user types an email-like sequence (no word boundary before '@')
+        for key in ['b', 'a', 'r', 't', 'at']:
+            await pilot.press(key)
+        await pilot.pause()
+        # THEN the overlay is not opened
+        assert screen._mention_overlay_open is False
+        assert len(screen.query('#mention-overlay')) == 0
+        assert screen.comment_textarea.text == 'bart@'
+
+
+@pytest.mark.asyncio
+async def test_mention_overlay_not_opened_when_adf_disabled(app):
+    with patch.object(APIController, '_adf_support_enabled', return_value=False):
+        async with app.run_test() as pilot:
+            screen = AddCommentScreen('WI-1')
+            await app.push_screen(screen)
+            await pilot.pause()
+            # WHEN the user types '@' but ADF is not supported (e.g. Jira DC / API v2)
+            await pilot.press('at')
+            await pilot.pause()
+            # THEN no overlay opens and the '@' remains as literal text
+            assert screen._mention_overlay_open is False
+            assert len(screen.query('#mention-overlay')) == 0
+            assert screen.comment_textarea.text == '@'
+
+
+@pytest.mark.asyncio
+async def test_selecting_user_inserts_mention_token(app):
+    from jiratui.widgets.comments.add import MentionAutoComplete
+
+    async with app.run_test() as pilot:
+        screen = AddCommentScreen('WI-1')
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press('at')
+        await pilot.pause()
+        assert screen._mention_overlay_open is True
+        # WHEN a user is selected from the mention autocomplete
+        screen.post_message(
+            MentionAutoComplete.UserSelected(
+                account_id='557058:abc-123', display_name='Homer Simpson'
+            )
+        )
+        await pilot.pause()
+        # THEN the trigger '@' is replaced by a mention token and the overlay closes
+        assert screen.comment_textarea.text == '@[Homer Simpson](557058:abc-123)'
+        assert screen._mention_overlay_open is False
+        assert len(screen.query('#mention-overlay')) == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelling_mention_restores_literal_at(app):
+    async with app.run_test() as pilot:
+        screen = AddCommentScreen('WI-1')
+        await app.push_screen(screen)
+        await pilot.pause()
+        await pilot.press('at')
+        await pilot.pause()
+        assert screen._mention_overlay_open is True
+        # WHEN the user cancels the mention picker with Escape
+        await pilot.press('escape')
+        await pilot.pause()
+        # THEN the overlay closes, the literal '@' remains and the screen is not popped
+        assert screen._mention_overlay_open is False
+        assert len(screen.query('#mention-overlay')) == 0
+        assert screen.comment_textarea.text == '@'
+        assert isinstance(app.screen, AddCommentScreen)
+
+
+@pytest.mark.asyncio
 async def test_add_comment_cancel_without_comment(app):
     async with app.run_test() as pilot:
         # WHEN


### PR DESCRIPTION
Typing '@' at a word boundary (or ctrl+@) while writing a comment on Jira Cloud (API v3) opens a user search overlay; selecting a user inserts an '@[Name](accountId)' token that is expanded to an ADF mention node on submit.

- src/jiratui/utils/mentions.py: pure token <-> marklas-span helpers
- controller._convert_comment_message_to_adf: expand mention tokens before ADF
- AddCommentScreen: @-triggered mention picker overlay, gated on cloud+v3
- tests: pure mention tests, comments pilot tests, controller integration test
- docs + CHANGELOG

Closes #125