### PR TITLE
JT-69: support autocomplete for parent field in details tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for keybindings styles. The app now supports a `legacy` style (default) or a `standard` style. This can be
 configured in the config file via the variable `key_bindings_style`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/327
-- Support autocomplete for selecting parent key in the details tab. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/328
+- Support autocomplete for selecting parent key in the details tab. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/329
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for keybindings styles. The app now supports a `legacy` style (default) or a `standard` style. This can be
 configured in the config file via the variable `key_bindings_style`. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/327
+- Support autocomplete for selecting parent key in the details tab. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/328
 
 ### Bug Fixes
 

--- a/src/jiratui/widgets/commons/base.py
+++ b/src/jiratui/widgets/commons/base.py
@@ -1055,7 +1055,7 @@ class WorkItemKeyAutoComplete(AutoComplete):
             self._search_work_items(search_string)
         return self._cached_suggestions
 
-    @work(group='create_subtask', exclusive=True)
+    @work(group='work_item_candidate_search', exclusive=True)
     async def _search_work_items(self, query: str) -> None:
         """Searches work items asynchronously.
 

--- a/src/jiratui/widgets/work_item_details/details.py
+++ b/src/jiratui/widgets/work_item_details/details.py
@@ -77,7 +77,11 @@ from jiratui.utils.work_item_updates import (
     work_item_reporter_has_changed,
 )
 from jiratui.widgets.base import ReadOnlyTextField
-from jiratui.widgets.commons.base import LabelsAutoComplete, MultiUserPickerAutoComplete
+from jiratui.widgets.commons.base import (
+    LabelsAutoComplete,
+    MultiUserPickerAutoComplete,
+    WorkItemKeyAutoComplete,
+)
 from jiratui.widgets.commons.users import JiraUserInput, UsersAutoComplete
 from jiratui.widgets.commons.widgets import (
     DateInputWidget,
@@ -294,12 +298,20 @@ class IssueDetailsWidget(Actionable, Vertical, inherit_bindings=False):  # type:
         return self.query_one('#issue-details-form', expect_type=VerticalScroll)
 
     @property
-    def support_sprint_selection(self) -> bool:
+    def _support_sprint_selection(self) -> bool:
         return CONFIGURATION.get().cloud
 
     @property
-    def support_updating_additional_fields(self) -> bool:
+    def _use_advanced_full_text_search(self) -> bool:
+        return CONFIGURATION.get().enable_advanced_full_text_search
+
+    @property
+    def _enable_updating_additional_fields(self) -> bool:
         return CONFIGURATION.get().enable_updating_additional_fields
+
+    @property
+    def _update_additional_fields_ignore_ids(self) -> list[str] | None:
+        return CONFIGURATION.get().update_additional_fields_ignore_ids
 
     def show_loading(self) -> None:
         """Shows the loading indicator and hides content."""
@@ -382,8 +394,6 @@ class IssueDetailsWidget(Actionable, Vertical, inherit_bindings=False):  # type:
             yield DynamicFieldsWidgets()  # the container for all the widgets created dynamically
 
     def on_mount(self) -> None:
-        """Initializes the autocomplete fields after mounting."""
-
         assignee_autocomplete = UsersAutoComplete(
             self.assignee_selector,
             self.app.api,  # type:ignore[attr-defined]
@@ -395,7 +405,39 @@ class IssueDetailsWidget(Actionable, Vertical, inherit_bindings=False):  # type:
             self.app.api,  # type:ignore[attr-defined]
             id='details-reporter-autocomplete',
         ).add_class(*['cols-3'])
-        self.mount_all([assignee_autocomplete, reporter_autocomplete])
+        work_item_parent_key_autocomplete = WorkItemKeyAutoComplete(
+            self.issue_parent_field,
+            self.app.api,  # type:ignore[attr-defined]
+            work_items_search_function=self._search_work_item_parent_options,
+        ).add_class(*['cols-3'])
+        self.mount_all(
+            [assignee_autocomplete, reporter_autocomplete, work_item_parent_key_autocomplete]
+        )
+
+    async def _search_work_item_parent_options(self, query: str) -> list[JiraIssue] | None:
+        """Searches and retrieves work items to fill in the autocomplete suggestions for parent key.
+
+        See Also: https://support.atlassian.com/jira-software-cloud/docs/jql-fields/
+
+        Args:
+            query: the search term to find work items.
+
+        Returns:
+            A list of `JiraIssue` instances of None if it fails to search work items.
+        """
+
+        if query:
+            jql_query = f'summary ~ "{query}" OR description ~ "{query}" OR workItemKey ~ "{query}"'
+            if self._use_advanced_full_text_search:
+                jql_query = f'text ~ "{query}" OR workItemKey ~ "{query}"'
+            if self.issue.project.key:
+                jql_query = f'({jql_query}) AND (spaceJira = "{self.issue.project.key}")'
+            response: APIControllerResponse = await self.app.api.search_issues(  # type:ignore[attr-defined]
+                jql_query=jql_query, fields=['id', 'key', 'summary']
+            )
+            if response.success and response.result is not None:
+                return response.result.issues
+        return None
 
     async def _search_and_filter_assignees(self, query: str) -> APIControllerResponse:
         # searches and filters users that can be assignees of the work item being edited
@@ -620,7 +662,7 @@ class IssueDetailsWidget(Actionable, Vertical, inherit_bindings=False):  # type:
                 return None
 
         # process dynamically-generated field widgets; e.g. additional system fields and custom fields
-        if CONFIGURATION.get().enable_updating_additional_fields:
+        if self._enable_updating_additional_fields:
             # process the "dynamic" fields, which include custom and system fields
             for dynamic_widget in self.dynamic_fields_widgets_container.children:
                 if (
@@ -954,7 +996,7 @@ class IssueDetailsWidget(Actionable, Vertical, inherit_bindings=False):  # type:
         # check if the work item has been flagged; and show a label at the top with a message for the user
         self.run_worker(self._determine_issue_flagged_status(work_item))
 
-        if self.support_updating_additional_fields:
+        if self._enable_updating_additional_fields:
             # add dynamic widgets to support updating custom fields and other system fields
             self.run_worker(self._add_dynamic_widgets(work_item))
 
@@ -975,7 +1017,7 @@ class IssueDetailsWidget(Actionable, Vertical, inherit_bindings=False):  # type:
         """
 
         # get filter configuration to ignore fields from the dynamic form
-        ignore_filter_ids = CONFIGURATION.get().update_additional_fields_ignore_ids
+        ignore_filter_ids = self._update_additional_fields_ignore_ids
         await self.dynamic_fields_widgets_container.remove_children()
         dynamic_widgets: list[Widget]
         if dynamic_widgets := create_dynamic_widgets_for_updating_work_item(
@@ -1012,7 +1054,7 @@ class IssueDetailsWidget(Actionable, Vertical, inherit_bindings=False):  # type:
                 await self.dynamic_fields_widgets_container.mount(
                     LabelsAutoComplete(target=widget, api_controller=self.app.api)  # type:ignore
                 )
-            if sprint_selection_widgets and self.support_sprint_selection:
+            if sprint_selection_widgets and self._support_sprint_selection:
                 await self._setup_sprint_selection_widgets(work_item.project.key)
 
     async def _setup_sprint_selection_widgets(self, project_key: str) -> None:

--- a/src/jiratui/widgets/work_item_details/fields.py
+++ b/src/jiratui/widgets/work_item_details/fields.py
@@ -120,10 +120,6 @@ class IssueParentField(Input):
         if event.value is not None:
             self.value = event.value.strip()
 
-    def on_input_changed(self, event: Input.Changed) -> None:
-        if event.value:
-            self.value = event.value.strip()
-
     def _update_required_status(self, required: bool) -> None:
         if required:
             self.border_subtitle = '(*)'

--- a/src/jiratui/widgets/work_item_details/tests/test_issue_details_widget.py
+++ b/src/jiratui/widgets/work_item_details/tests/test_issue_details_widget.py
@@ -1127,7 +1127,7 @@ async def test_build_payload_for_update_update_additional_fields_enabled_non_num
             assert payload == {'field_a': expected_value}
 
 
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @pytest.mark.asyncio
 async def test_clear_form_with_support_for_sprint_selection(app: JiraApp):
     # GIVEN
@@ -1395,7 +1395,7 @@ async def test_watch_issue(jira_issue, app: JiraApp):
         assert result is None
 
 
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @patch.object(IssueDetailsWidget, '_setup_time_tracking')
 @patch.object(IssueDetailsWidget, '_add_dynamic_widgets')
 @patch.object(IssueDetailsWidget, '_determine_issue_flagged_status')
@@ -1570,7 +1570,7 @@ async def test_add_dynamic_widgets(
 
 
 @patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
 @pytest.mark.asyncio
 async def test_add_dynamic_widgets_with_support_for_sprint_selection_without_current_sprint(
@@ -1612,7 +1612,7 @@ async def test_add_dynamic_widgets_with_support_for_sprint_selection_without_cur
 
 
 @patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
 @pytest.mark.asyncio
 async def test_add_dynamic_widgets_with_support_for_sprint_selection_with_current_sprint_selected(
@@ -1658,7 +1658,7 @@ async def test_add_dynamic_widgets_with_support_for_sprint_selection_with_curren
 
 
 @patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
 @pytest.mark.asyncio
 async def test_add_dynamic_widgets_with_support_for_sprint_selection_with_current_sprint_in_past_selected(
@@ -1705,7 +1705,7 @@ async def test_add_dynamic_widgets_with_support_for_sprint_selection_with_curren
 
 
 @patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
 @pytest.mark.asyncio
 async def test_add_dynamic_widgets_with_support_for_sprint_selection_no_sprints_found(
@@ -1742,7 +1742,7 @@ async def test_add_dynamic_widgets_with_support_for_sprint_selection_no_sprints_
 
 
 @patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
 @pytest.mark.asyncio
 async def test_add_dynamic_widgets_with_support_for_sprint_selection_no_sprints_found_using_original_value(
@@ -1780,7 +1780,7 @@ async def test_add_dynamic_widgets_with_support_for_sprint_selection_no_sprints_
 
 
 @patch.object(IssueDetailsWidget, '_fetch_sprints_in_project')
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=False))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=False))
 @patch('jiratui.widgets.work_item_details.details.create_dynamic_widgets_for_updating_work_item')
 @pytest.mark.asyncio
 async def test_add_dynamic_widgets_without_support_for_sprint_selection(
@@ -1812,7 +1812,7 @@ async def test_add_dynamic_widgets_without_support_for_sprint_selection(
         assert isinstance(children[1], MultiUserPickerAutoComplete)
 
 
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @pytest.mark.asyncio
 async def test_static_widgets_css_classes_with_support_for_sprint_selection(
     jira_issue, app: JiraApp
@@ -2072,9 +2072,9 @@ async def test_fetch_sprints_in_project_with_sprints_in_session_fetching_succeed
 
 @patch('jiratui.widgets.work_item_details.factory._uses_cloud_api')
 @patch.object(
-    IssueDetailsWidget, 'support_updating_additional_fields', PropertyMock(return_value=True)
+    IssueDetailsWidget, '_enable_updating_additional_fields', PropertyMock(return_value=True)
 )
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=False))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=False))
 @pytest.mark.asyncio
 async def test_set_issue_without_support_for_sprint_selection_with_current_sprint(
     uses_cloud_api_mock: Mock, jira_issue: JiraIssue, app: JiraApp
@@ -2111,9 +2111,9 @@ async def test_set_issue_without_support_for_sprint_selection_with_current_sprin
 
 @patch('jiratui.widgets.work_item_details.factory._uses_cloud_api')
 @patch.object(
-    IssueDetailsWidget, 'support_updating_additional_fields', PropertyMock(return_value=True)
+    IssueDetailsWidget, '_enable_updating_additional_fields', PropertyMock(return_value=True)
 )
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=False))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=False))
 @pytest.mark.asyncio
 async def test_set_issue_without_support_for_sprint_selection_without_current_sprint(
     uses_cloud_api_mock: Mock, jira_issue: JiraIssue, app: JiraApp
@@ -2155,10 +2155,10 @@ async def test_set_issue_without_support_for_sprint_selection_without_current_sp
 
 
 @patch.object(
-    IssueDetailsWidget, 'support_updating_additional_fields', PropertyMock(return_value=True)
+    IssueDetailsWidget, '_enable_updating_additional_fields', PropertyMock(return_value=True)
 )
 @patch('jiratui.widgets.work_item_details.factory._uses_cloud_api')
-@patch.object(IssueDetailsWidget, 'support_sprint_selection', PropertyMock(return_value=True))
+@patch.object(IssueDetailsWidget, '_support_sprint_selection', PropertyMock(return_value=True))
 @pytest.mark.asyncio
 async def test_set_issue_with_support_for_sprint_selection(
     uses_cloud_api_mock: Mock, jira_issue: JiraIssue, app: JiraApp


### PR DESCRIPTION
This PR adds support for searching work items using autocomplete. This is applicable in the details tab when updating a work item.

<img width="762" height="524" alt="Screenshot 2026-08-13 at 20 32 57" src="https://github.com/user-attachments/assets/fa5e4fd6-3d60-43f9-968b-53554068ec37" />
