### PR TITLE
JT-73: add CLI command to create items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ configured in the config file via the variable `key_bindings_style`. By [@whyisd
 - Fix parent-key autocomplete to skip child work item when updating work item details. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/330
 - Add ability to delete subtasks. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/335
 - Add ability view details using the quick-view screen for items in the search results table. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/336
+- Add a new CLI command `jiratui issues new` to create work items. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/337
 
 ### Bug Fixes
 

--- a/docs/users/usage/index.md
+++ b/docs/users/usage/index.md
@@ -861,8 +861,8 @@ In addition to the `ui` command, the CLI tool offers several commands to help yo
 users.
 
 ```{note}
-The CLI tool offers a simples interface for interacting with Jira when compared to the UI app. It's only meant to be
-used as a quick tool for some common tasks, for example, transitioning items from one staus to another. For a comore
+The CLI tool offers a simple interface for interacting with Jira when compared to the UI app. It's only meant to be
+used as a quick tool for some common tasks, for example, transitioning items from one staus to another. For a more
 complete experience the UI is recommended.
 ```
 
@@ -1117,4 +1117,94 @@ $ jiratui users groups --group-names developers
 | ID   | Name         | Total users in group? |
 |------|--------------|-----------------------|
 | 2    | developers   | 20                    |
+```
+
+### Creating New Work Items
+
+The CLI offers a basic command to create new work items.
+
+```{important}
+The CLI application only supports creating work items that require only the following fields:
+
+    - issuetype
+    - project
+    - reporter
+    - summary
+    - parent (for creating subtasks)
+
+If creating the work item requires any other field then the user needs to use the UI application.
+```
+
+The command to create a new work item is
+
+```shell
+jiratui issues new
+```
+
+You can use this command without arguments. In this case the command will ask you for the required input.
+
+Example:
+
+```shell
+jiratui issues new
+? Please specify the Jira project/space to which the work item belongs. (Use arrow keys)
+  > Project 1
+  Project 2
+? Please specify the type of work item to create. (Use arrow keys)
+  > Task
+  Bug
+? Provide the summary of the work item: Test summary
+Work item with key WI-123 created successfully
+View it with: jiratui issues search -k WI-123
+```
+
+You can also pass some of the required arguments. This includes:
+
+- the project's key (`-p 123`)
+- the id of the type of item (`-t 10001`)
+- the summary (`-s 'Some text'`)
+
+```shell
+jiratui issues new -p 123 -t 1001 -s 'Implement...'
+```
+
+```{tip}
+You can cancel the command at any time with `ctrl+c`.
+```
+
+### Cloning Work Items
+
+To clone an item simply pass the key of the source item and an optional summary. If no summary is
+provided then the new item's summary will be set to `(clone) <original summary>`.
+
+```{important}
+Cloning a work item will only clone these fields:
+- summary
+- project
+- priority
+- status (optional)
+- description
+- type
+- due date
+- assignee
+- reporter
+- parent
+```
+
+```shell
+jiratui issues clone WI-123 -s 'The new summary...' --clone-status
+```
+
+If you also want to clone the status of the source item then you can run it as
+
+```shell
+jiratui issues clone WI-123 -s 'The new summary...' --clone-status
+```
+
+### Deleting Work Items
+
+To delete an item run the following
+
+```shell
+jiratui issues delete WI-123
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "pydantic-settings[yaml]>=2.14.2,<3.0.0",
     "python-dateutil>=2.9.0.post0",
     "python-json-logger>=4.1.0,<5.0.0",
+    "questionary>=2.1.1",
     "textual-autocomplete>=4.0.6",
     "textual-image>=0.13.2,<0.14.0",
     "textual[syntax]>=8.2.7,<9.0.0",

--- a/src/jiratui/cli.py
+++ b/src/jiratui/cli.py
@@ -29,6 +29,7 @@ from jiratui.config import ApplicationConfiguration
 from jiratui.configuration_app import JiraTUIConfigurationApp
 from jiratui.exceptions import CLIException
 from jiratui.files import get_config_file
+from jiratui.models import JiraUserGroup
 
 console = Console()
 
@@ -100,6 +101,15 @@ def config():
     help='The path to the file where the configuration will be saved.',
 )
 def configure_create(output_file: str | None = None) -> None:
+    """Launches the configuration management tool.
+
+    Args:
+        output_file: the file to save the configuration.
+
+    Returns:
+        None
+    """
+
     JiraTUIConfigurationApp(output_file=output_file).run()
 
 
@@ -141,16 +151,17 @@ def search_issues(
     """Searches work items.
 
     Args:
-        project_key:
-        key:
-        assignee_account_id:
-        limit:
-        created_from:
-        created_until:
+        project_key: searches work items in the project/space identified by this (case-sensitive) key.
+        key: searches a single work item identified by this (case-sensitive) key.
+        assignee_account_id: searches work items assigned to the user identified by this id.
+        limit: searches a maximum of this number of work items. Default is 50.
+        created_from: searches work items created from this date (inclusive). Expects YYYY-MM-DD.
+        created_until: searches work items created until this date (inclusive). Expects YYYY-MM-DD.
 
     Returns:
-
+        None
     """
+
     if not project_key and not key:
         raise click.BadParameter(
             'One of --project-key (-p) or --key (-k) must be provided',
@@ -255,7 +266,7 @@ def issue_metadata(work_item_key: str, field_id: str | None = None) -> None:
     is_flag=True,
     type=bool,
     default=False,
-    help='Shows metadata for an issue. This is useful for updates.',
+    help='Shows (edit) metadata for an issue. This is useful for updates.',
 )
 @click.option(
     '--status-id',
@@ -277,10 +288,22 @@ def update_issue(
     meta: bool | None = None,
     status_id: int | None = None,
     priority_id: int | None = None,
-):
-    """Updates (some) fields of the work item identified by WORK_ITEM_KEY."""
+) -> None:
+    """Updates (some) fields of the work item identified by WORK_ITEM_KEY.
 
-    # WORK_ITEM_KEY is the case-sensitive key that identifies the work item we want to update.
+    Args:
+        work_item_key: the case-sensitive key that identifies the work item we want to update.
+        summary: the summary to set up.
+        assignee_account_id: the account ID of the user to whom the work item will be assigned.
+        due_date: the due date of an issue. Expects YYYY-MM-DD.
+        meta: if True then the command shows (edit) metadata for an issue.
+        status_id: the ID of the status to set for the work item.
+        priority_id: the ID of the priority to set for the work item.
+
+    Returns:
+        None
+    """
+
     handler = CommandHandler()
 
     if meta:
@@ -430,9 +453,42 @@ def delete_work_item(work_item_key: str) -> None:
             renderer = CLIExceptionRenderer()
             renderer.render(console, e.get_extra_details())
         except Exception as e:
-            console.print(f'Unable to delete the selected work item. {str(e)}')
+            console.print(f'Unable to delete the selected work item. {str(e)}', style='bold red')
         else:
-            console.print('Work item deleted successfully.')
+            console.print('Work item deleted successfully.', style='bold green')
+
+
+@issues.command('new')
+@click.option(
+    '--project-key', '-p', type=str, help='A case-sensitive key that identifies a project.'
+)
+@click.option('--summary', '-s', type=str, help='A case-sensitive key that identifies a project.')
+@click.option(
+    '--work_item_type', '-t', type=str, help='A case-sensitive key that identifies a project.'
+)
+def create_work_item(
+    project_key: str | None = None, summary: str | None = None, work_item_type: str | None = None
+) -> None:
+    """Creates a new work item.
+
+    Args:
+        project_key: the key of the Jira projetc/space to which the work item belongs. If missing, the application will
+        prompt the user to enter it.
+        summary: a short summary of the work item. If missing, the application will prompt the user to enter it.
+        work_item_type: the type of work item to create. If missing, the application will prompt the user to enter it.
+
+    Returns:
+        None
+    """
+
+    handler = CommandHandler()
+    try:
+        response: str = asyncio.run(handler.create_work_item(project_key, work_item_type, summary))
+    except CLIException as e:
+        console.print(str(e), style='bold red')
+    else:
+        console.print(f'Work item with key {response} created successfully', style='bold green')
+        console.print(f'View it with: jiratui issues search -k {response}')
 
 
 # -- PROJECTS --
@@ -450,8 +506,10 @@ def delete_work_item(work_item_key: str) -> None:
 def create_metadata(project_key: str, work_item_type_id: str, save_as: str | None = None) -> None:
     """Retrieves create-metadata for the requested project key and type of work item.
 
-    PROJECT_KEY case-sensitive key that identifies a project in your organization.
-    WORK_ITEM_TYPE_ID the id that identifies a type of work item in the project.
+    Args:
+        project_key: case-sensitive key that identifies a project in your organization.
+        work_item_type_id: the id that identifies a type of work item in the project.
+        save_as: an optional filename to export the JSON result.
     """
 
     handler = CommandHandler()
@@ -480,12 +538,14 @@ def create_metadata(project_key: str, work_item_type_id: str, save_as: str | Non
 @comments.command('add')
 @click.argument('work-item-key')
 @click.argument('message')
-def add_comment(message: str, work_item_key: str):
+def add_comment(message: str, work_item_key: str) -> None:
     """Adds a comment to the work item identified by WORK_ITEM_KEY.
 
-    WORK_ITEM_KEY is the case-sensitive key that identifies the work item.
-    MESSAGE is the message of the comment.
+    Args:
+        work_item_key: is the case-sensitive key that identifies the work item.
+        message: is the message of the comment.
     """
+
     handler = CommandHandler()
     with console.status('Trying to add the comment to the issue...'):
         try:
@@ -509,11 +569,15 @@ def add_comment(message: str, work_item_key: str):
     help='The page number we want to retrieve. The max number of items per page is 10',
 )
 @click.option('--comment-id', '-c', default=None, help='The ID of a comment')
-def list_comments(work_item_key: str, page: int = 1, comment_id: str | None = None):
+def list_comments(work_item_key: str, page: int = 1, comment_id: str | None = None) -> None:
     """Lists the comments of the work item identified by WORK_ITEM_KEY.
 
-    WORK_ITEM_KEY is the case-sensitive key that identifies the work item.
+    Args:
+        work_item_key: is the case-sensitive key that identifies the work item.
+        page: is the page number we want to retrieve. The max number of items per page is 10.
+        comment_id: if provided then only the comment with this Id will be retrieved.
     """
+
     handler = CommandHandler()
     with console.status('Fetching comments for the issue...'):
         try:
@@ -533,9 +597,11 @@ def list_comments(work_item_key: str, page: int = 1, comment_id: str | None = No
 def show_comment(work_item_key: str, comment_id: str) -> None:
     """Shows the text of a comment of the work item identified by WORK_ITEM_KEY.
 
-    WORK_ITEM_KEY is the case-sensitive key that identifies the work item.
-    COMMENT_ID the id of the comment whose text we want to view.
+    Args:
+        work_item_key: is the case-sensitive key that identifies the work item.
+        comment_id: the id of the comment whose text we want to view.
     """
+
     handler = CommandHandler()
     with console.status('Fetching comment...'):
         try:
@@ -552,12 +618,14 @@ def show_comment(work_item_key: str, comment_id: str) -> None:
 @comments.command('delete')
 @click.argument('work-item-key')
 @click.argument('comment-id')
-def delete_comment(work_item_key: str, comment_id: str):
+def delete_comment(work_item_key: str, comment_id: str) -> None:
     """Deletes the comment with id COMMENT_ID of the work item identified by WORK_ITEM_KEY.
 
-    WORK_ITEM_KEY is the case-sensitive key that identifies the work item.
-    COMMENT_ID the id of the comment whose text we want to view.
+    Args:
+        work_item_key: is the case-sensitive key that identifies the work item.
+        comment_id: the id of the comment whose text we want to view.
     """
+
     handler = CommandHandler()
     with console.status('Trying to delete the comment...'):
         try:
@@ -629,8 +697,23 @@ def ui(
     theme: str | None = None,
     search_on_startup: bool = False,
     focus_item_on_startup: int | None = None,
-):
-    """Launches the JiraTUI application."""
+) -> None:
+    """Launches the JiraTUI application.
+
+    Args:
+        project_key: if provided then the application will use this key to set up the project selection dropdown.
+        work_item_key: if provided then the application will use this key to set up the work item filter.
+        assignee_account_id: if provided then the application will use this id to set up the assignee filter.
+        jql_expression_id: if provided the application wil set the JQL search filter with the JQL expression given by
+        this id.
+        theme: if provided then the application will use this theme.
+        search_on_startup: if True then the application will run a search on start-up using the search filters.
+        focus_item_on_startup: if provided then the application will focus on the work item at the specified position
+        in the search results. This requires `search_on_startup`.
+
+    Returns:
+        None
+    """
 
     # check that the config file exists
     try:
@@ -700,11 +783,13 @@ def check_config_file() -> None:
 
 @users.command('search')
 @click.argument('email_or_name')
-def search_users(email_or_name: str):
+def search_users(email_or_name: str) -> None:
     """Searches users by email or name. This is useful for getting the account ID of users.
 
-    EMAIL_OR_NAME is the email address or name to search users.
+    Args:
+        email_or_name: is the email address or name to search users.
     """
+
     handler = CommandHandler()
     with console.status('Searching Jira users...'):
         try:
@@ -749,7 +834,17 @@ def search_users_groups(
     group_id: str | None = None,
     page: int = 1,
 ) -> None:
-    """Searches Jira users groups. Use it to find groups of users by name or ID."""
+    """Searches Jira users groups. Use it to find groups of users by name or ID.
+
+    Args:
+        group_ids:
+        group_names:
+        group_id:
+        page:
+
+    Returns:
+        None
+    """
 
     handler = CommandHandler()
     if group_id:
@@ -768,7 +863,7 @@ def search_users_groups(
     with console.status('Searching Jira user groups...'):
         # find Jira users groups
         try:
-            items = handler.search_user_groups(
+            items: list[JiraUserGroup] = handler.search_user_groups(
                 page=page,
                 group_ids=[gid.strip() for gid in group_ids.split(',')] if group_ids else None,
                 group_names=[gn.strip() for gn in group_names.split(',')] if group_names else None,

--- a/src/jiratui/commands/handler.py
+++ b/src/jiratui/commands/handler.py
@@ -2,6 +2,8 @@ import asyncio
 from datetime import date
 from typing import Any
 
+import questionary
+
 from jiratui.api_controller.controller import APIController, APIControllerResponse
 from jiratui.config import CONFIGURATION, ApplicationConfiguration
 from jiratui.exceptions import (
@@ -12,11 +14,13 @@ from jiratui.exceptions import (
 from jiratui.models import (
     IssueComment,
     IssueTransition,
+    IssueType,
     JiraBaseIssue,
     JiraIssue,
     JiraIssueSearchResponse,
     JiraUser,
     JiraUserGroup,
+    Project,
 )
 from jiratui.utils.work_item_updates import (
     work_item_assignee_has_changed,
@@ -28,9 +32,21 @@ COMMENTS_PER_PAGE = 10
 
 
 class CommandHandler:
+    CREATE_ITEM_SUPPORTED_FIELDS: set[str] = {
+        'issuetype',
+        'project',
+        'reporter',
+        'summary',
+        'parent',
+    }
+
     def __init__(self):
         CONFIGURATION.set(ApplicationConfiguration())  # type:ignore[call-arg]
         self.api = APIController()
+
+    @property
+    def jira_account_id(self) -> str | None:
+        return CONFIGURATION.get().jira_account_id
 
     def users(self, email_or_name: str) -> list[JiraUser]:
         """Searches Jira users by name or email.
@@ -83,11 +99,11 @@ class CommandHandler:
                 groups_names=group_names,
             )
         )
-        if not response.success:
+        if not response.success or not response.result:
             raise CLIException(
                 f'An error occurred while searching for user groups: {response.error}'
             )
-        return response.result
+        return response.result or []
 
     def total_users_in_group(self, group_id: str | None = None) -> int:
         """Counts the number of users in a group.
@@ -104,11 +120,11 @@ class CommandHandler:
         response: APIControllerResponse = asyncio.run(
             self.api.count_users_in_group(group_id=group_id)
         )
-        if not response.success:
+        if not response.success or response.result is None:
             raise CLIException(
                 f'An error occurred while counting the users in the group: {response.error}'
             )
-        return response.result
+        return response.result or 0
 
     def add_comment(self, key: str, message: str) -> IssueComment | None:
         """Adds a comment to a work item.
@@ -367,7 +383,7 @@ class CommandHandler:
                 order_by=CONFIGURATION.get().search_results_default_order,
             )
         )
-        if response.success:
+        if response.success and response.result is not None:
             return response.result
         raise CLIException(response.error)
 
@@ -630,3 +646,149 @@ class CommandHandler:
                 extra={'work_item_key': work_item_key, 'error_message': response.error},
             )
         return True
+
+    async def projects(self) -> list[Project] | None:
+        """Searches Jira users by name or email.
+
+        Returns:
+            A list of `JiraUser` instances.
+
+        Raises:
+            CLIException: if an error occurs while fetching the users.
+            CLIException: if no email or name is provided.
+        """
+
+        response: APIControllerResponse = await self.api.search_projects()
+        if not response.success:
+            raise CLIException(f'An error occurred while searching for projects: {response.error}')
+        return response.result
+
+    async def work_item_types_by_project(self, project_key: str) -> list[IssueType] | None:
+        """Searches Jira users by name or email.
+
+        Args:
+            project_key:
+
+        Returns:
+            A list of `JiraUser` instances.
+
+        Raises:
+            CLIException: if an error occurs while fetching the users.
+            CLIException: if no email or name is provided.
+        """
+
+        response: APIControllerResponse = await self.api.get_issue_types_for_project(project_key)
+        if not response.success:
+            raise CLIException(
+                f'An error occurred while searching for work item types: {response.error}'
+            )
+        return response.result
+
+    async def create_work_item(
+        self,
+        project_key: str | None = None,
+        work_item_type_id: str | None = None,
+        summary: str | None = None,
+    ) -> str:
+        """Creates a new work item.
+
+        The CLI application only supports creating work items that require only the following fields:
+
+        - issuetype
+        - project
+        - reporter
+        - summary
+
+        If creating the work item requires any other field then the user needs to use the UI application.
+
+        Args:
+            project_key: the key of the Jira projetc/space to which the work item belongs. If missing, the application
+            will prompt the user to enter it.
+            work_item_type_id: the type of work item to create. If missing, the application will prompt the user to
+            enter it.
+            summary: a short summary of the work item. If missing, the application will prompt the user to enter it.
+
+        Returns:
+            The key of the newly created work item.
+
+        Raises:
+            CLIException: if the required project key is missing.
+            CLIException: if the required type of work item is missing.
+            CLIException: if the work item can not be created.
+            CLIException: if the creation fails.
+        """
+
+        payload: dict[str, Any] = {}
+
+        if not project_key:
+            # fetch the list of projects
+            response: list[Project] | None = await self.projects()
+            if not response:
+                raise CLIException('No project was found')
+            # ask the user to choose a project
+            project_key = await questionary.select(
+                'Please specify the Jira project/space to which the work item belongs.',
+                choices=[
+                    questionary.Choice(project.name, project.key) for project in response or []
+                ],
+            ).ask_async()
+            if not project_key:
+                raise CLIException('Validation Error: the project/space key is required')
+
+        if not work_item_type_id:
+            # choose the type of issue
+            response_work_item_types = await self.work_item_types_by_project(project_key)
+            work_item_type_id = await questionary.select(
+                'Please specify the type of work item to create.',
+                choices=[
+                    questionary.Choice(record.name, record.id)
+                    for record in response_work_item_types or []
+                ],
+            ).ask_async()
+            if not work_item_type_id:
+                raise CLIException('Validation Error: the type of work item is required')
+
+        # fetch create-metadata to determine if we can create the item based on the required fields
+        create_metadata: dict = await self.get_create_metadata(project_key, work_item_type_id)
+        if create_metadata and (metadata := create_metadata.get('metadata', {})):
+            required_fields: set[str] = {
+                x.get('fieldId') for x in metadata.get('fields', []) if x.get('required')
+            }
+            if not required_fields.issubset(self.CREATE_ITEM_SUPPORTED_FIELDS):
+                required = ', '.join(sorted(required_fields))
+                raise CLIException(
+                    f'Creating this type of work item for the given project requires the fields: {required}. This is not supported via the CLI. Use the UI application instead.'
+                )
+
+            # check if the use defined the account_id in the config; if not fail with a hint.
+            if 'reporter' in required_fields:
+                if not self.jira_account_id:
+                    raise CLIException(
+                        "Creating this type of work item via the CLI requires your user's Jira account ID to be defined in the configuration file. This is required to set the reporter of the issue."
+                    )
+
+                payload['reporter_account_id'] = self.jira_account_id
+
+            if 'parent' in required_fields:
+                parent_key = await questionary.text(
+                    'Please specify the key of the parent work item.',
+                    validate=lambda text: True if len(text) > 0 else 'Please enter a value',
+                ).ask_async()
+                payload['parent_key'] = parent_key
+
+        if not summary:
+            # ask for summary
+            summary = await questionary.text(
+                'Provide the summary of the work item',
+                validate=lambda text: True if len(text) > 0 else 'Please enter a value',
+            ).ask_async()
+
+        payload['project_key'] = project_key
+        payload['issue_type_id'] = work_item_type_id
+        payload['summary'] = summary
+
+        create_response: APIControllerResponse = await self.api.create_work_item(payload)
+        item: JiraBaseIssue | None
+        if create_response.success and (item := create_response.result):
+            return item.key
+        raise CLIException(create_response.error)

--- a/src/jiratui/commands/tests/test_handlers.py
+++ b/src/jiratui/commands/tests/test_handlers.py
@@ -1,8 +1,9 @@
 from datetime import date, datetime
 import re
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, PropertyMock, call, patch
 
 import pytest
+import questionary
 
 from jiratui.api_controller.controller import APIController, APIControllerResponse
 from jiratui.commands.handler import CommandHandler
@@ -1547,3 +1548,478 @@ async def test_clone_work_item_cloning_succeeds_with_custom_summary(
         'key': 'WI-2',
         'work_item': JiraIssueSearchResponse(issues=[cloned_issue]),
     }
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_without_user_input(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    # WHEN
+    result = await handler.create_work_item('P1', '1', summary='Custom summary')
+    # THEN
+    assert result == 'WI-1'
+    get_create_metadata_mock.assert_awaited_once_with('P1', '1')
+    create_work_item_mock.assert_awaited_once_with(
+        {
+            'project_key': 'P1',
+            'issue_type_id': '1',
+            'summary': 'Custom summary',
+            'reporter_account_id': '12345',
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_without_user_input_creation_fails(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(success=False, error='Some error')
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    # WHEN
+    with pytest.raises(
+        CLIException,
+        match='Some error',
+    ):
+        await handler.create_work_item('P1', '1', summary='Custom summary')
+    # THEN
+    get_create_metadata_mock.assert_awaited_once_with('P1', '1')
+    create_work_item_mock.assert_awaited_once_with(
+        {
+            'project_key': 'P1',
+            'issue_type_id': '1',
+            'summary': 'Custom summary',
+            'reporter_account_id': '12345',
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_without_user_input_unsupported_required_fields(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+                {'fieldId': 'duedate', 'required': True},
+            ]
+        }
+    }
+    # WHEN
+    with pytest.raises(
+        CLIException,
+        match='Creating this type of work item for the given project requires the fields: duedate, issuetype, project, reporter, summary. This is not supported via the CLI. Use the UI application instead.',
+    ):
+        await handler.create_work_item('P1', '1', summary='Custom summary')
+    # THEN
+    get_create_metadata_mock.assert_awaited_once_with('P1', '1')
+    create_work_item_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value=None))
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_without_user_input_missing_jira_account_id(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    # WHEN
+    with pytest.raises(
+        CLIException,
+        match="Creating this type of work item via the CLI requires your user's Jira account ID to be defined in the configuration file. This is required to set the reporter of the issue.",
+    ):
+        await handler.create_work_item('P1', '1', summary='Custom summary')
+    # THEN
+    get_create_metadata_mock.assert_awaited_once_with('P1', '1')
+    create_work_item_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(CommandHandler, 'projects')
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_ask_user_input_project_key_no_projects_found(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+    projects_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    projects_mock.return_value = []
+    # WHEN
+    with pytest.raises(CLIException, match='No project was found'):
+        await handler.create_work_item(None, '1', summary='Custom summary')
+    # THEN
+    projects_mock.assert_awaited_once()
+    get_create_metadata_mock.assert_not_awaited()
+    create_work_item_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(questionary.Question, 'ask_async')
+@patch.object(CommandHandler, 'projects')
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_ask_user_input_project_key_no_project_provided(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+    projects_mock: AsyncMock,
+    ask_async_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    projects_mock.return_value = [Project(id='1', key='P2', name='P2')]
+    ask_async_mock.return_value = ''
+    # WHEN
+    with pytest.raises(CLIException, match='Validation Error: the project/space key is required'):
+        await handler.create_work_item(None, '1', summary='Custom summary')
+    # THEN
+    ask_async_mock.assert_awaited_once()
+    projects_mock.assert_awaited_once()
+    get_create_metadata_mock.assert_not_awaited()
+    create_work_item_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(questionary.Question, 'ask_async')
+@patch.object(CommandHandler, 'projects')
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_ask_user_input_project_key_provided(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+    projects_mock: AsyncMock,
+    ask_async_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    projects_mock.return_value = [Project(id='1', key='P2', name='P2')]
+    ask_async_mock.return_value = 'P2'
+    # WHEN
+    await handler.create_work_item(None, '1', summary='Custom summary')
+    # THEN
+    ask_async_mock.assert_awaited_once()
+    projects_mock.assert_awaited_once()
+    get_create_metadata_mock.assert_awaited_once_with('P2', '1')
+    create_work_item_mock.assert_awaited_once_with(
+        {
+            'project_key': 'P2',
+            'issue_type_id': '1',
+            'summary': 'Custom summary',
+            'reporter_account_id': '12345',
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(questionary.Question, 'ask_async')
+@patch.object(CommandHandler, 'work_item_types_by_project')
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_ask_user_input_item_type_no_type_provided(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+    work_item_types_by_project_mock: AsyncMock,
+    ask_async_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    work_item_types_by_project_mock.return_value = [IssueType(id='1', name='Task')]
+    ask_async_mock.return_value = ''
+    # WHEN
+    with pytest.raises(CLIException, match='Validation Error: the type of work item is required'):
+        await handler.create_work_item('P1', None, summary='Custom summary')
+    # THEN
+    ask_async_mock.assert_awaited_once()
+    get_create_metadata_mock.assert_not_awaited()
+    create_work_item_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(questionary.Question, 'ask_async')
+@patch.object(CommandHandler, 'work_item_types_by_project')
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_ask_user_input_item_type_provided(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+    work_item_types_by_project_mock: AsyncMock,
+    ask_async_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    work_item_types_by_project_mock.return_value = [IssueType(id='1', name='Task')]
+    ask_async_mock.return_value = '10001'
+    # WHEN
+    await handler.create_work_item('P1', None, summary='Custom summary')
+    # THEN
+    ask_async_mock.assert_awaited_once()
+    get_create_metadata_mock.assert_awaited_once_with('P1', '10001')
+    create_work_item_mock.assert_awaited_once_with(
+        {
+            'project_key': 'P1',
+            'issue_type_id': '10001',
+            'summary': 'Custom summary',
+            'reporter_account_id': '12345',
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(questionary.Question, 'ask_async')
+@patch.object(CommandHandler, 'projects')
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_ask_user_input_summary_provided(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+    projects_mock: AsyncMock,
+    ask_async_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    ask_async_mock.return_value = 'Test summary'
+    # WHEN
+    await handler.create_work_item('P1', '1', None)
+    # THEN
+    ask_async_mock.assert_awaited_once()
+    projects_mock.assert_not_awaited()
+    get_create_metadata_mock.assert_awaited_once_with('P1', '1')
+    create_work_item_mock.assert_awaited_once_with(
+        {
+            'project_key': 'P1',
+            'issue_type_id': '1',
+            'summary': 'Test summary',
+            'reporter_account_id': '12345',
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(questionary.Question, 'ask_async')
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_ask_user_required_parent_key(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+    ask_async_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+                {'fieldId': 'parent', 'required': True},
+            ]
+        }
+    }
+    ask_async_mock.return_value = 'P3'
+    # WHEN
+    await handler.create_work_item('P1', '1', 'Test summary')
+    # THEN
+    ask_async_mock.assert_awaited_once()
+    get_create_metadata_mock.assert_awaited_once_with('P1', '1')
+    create_work_item_mock.assert_awaited_once_with(
+        {
+            'project_key': 'P1',
+            'issue_type_id': '1',
+            'summary': 'Test summary',
+            'reporter_account_id': '12345',
+            'parent_key': 'P3',
+        }
+    )
+
+
+@pytest.mark.asyncio
+@patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
+@patch.object(questionary.Question, 'ask_async')
+@patch.object(CommandHandler, 'get_create_metadata')
+@patch.object(APIController, 'create_work_item')
+async def test_create_work_item_parent_key_not_required(
+    create_work_item_mock: AsyncMock,
+    get_create_metadata_mock: AsyncMock,
+    ask_async_mock: AsyncMock,
+):
+    # GIVEN
+    handler = CommandHandler()
+    create_work_item_mock.return_value = APIControllerResponse(
+        result=JiraBaseIssue(id='1', key='WI-1')
+    )
+    get_create_metadata_mock.return_value = {
+        'metadata': {
+            'fields': [
+                {'fieldId': 'summary', 'required': True},
+                {'fieldId': 'issuetype', 'required': True},
+                {'fieldId': 'project', 'required': True},
+                {'fieldId': 'reporter', 'required': True},
+            ]
+        }
+    }
+    ask_async_mock.return_value = 'P3'
+    # WHEN
+    await handler.create_work_item('P1', '1', 'Test summary')
+    # THEN
+    ask_async_mock.assert_not_awaited()
+    get_create_metadata_mock.assert_awaited_once_with('P1', '1')
+    create_work_item_mock.assert_awaited_once_with(
+        {
+            'project_key': 'P1',
+            'issue_type_id': '1',
+            'summary': 'Test summary',
+            'reporter_account_id': '12345',
+        }
+    )

--- a/src/jiratui/commands/tests/test_handlers.py
+++ b/src/jiratui/commands/tests/test_handlers.py
@@ -1551,14 +1551,18 @@ async def test_clone_work_item_cloning_succeeds_with_custom_summary(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(CommandHandler, 'get_create_metadata')
 @patch.object(APIController, 'create_work_item')
 async def test_create_work_item_without_user_input(
     create_work_item_mock: AsyncMock,
     get_create_metadata_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1589,14 +1593,18 @@ async def test_create_work_item_without_user_input(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(CommandHandler, 'get_create_metadata')
 @patch.object(APIController, 'create_work_item')
 async def test_create_work_item_without_user_input_creation_fails(
     create_work_item_mock: AsyncMock,
     get_create_metadata_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(success=False, error='Some error')
     get_create_metadata_mock.return_value = {
@@ -1628,14 +1636,18 @@ async def test_create_work_item_without_user_input_creation_fails(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(CommandHandler, 'get_create_metadata')
 @patch.object(APIController, 'create_work_item')
 async def test_create_work_item_without_user_input_unsupported_required_fields(
     create_work_item_mock: AsyncMock,
     get_create_metadata_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1663,14 +1675,18 @@ async def test_create_work_item_without_user_input_unsupported_required_fields(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value=None))
 @patch.object(CommandHandler, 'get_create_metadata')
 @patch.object(APIController, 'create_work_item')
 async def test_create_work_item_without_user_input_missing_jira_account_id(
     create_work_item_mock: AsyncMock,
     get_create_metadata_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1697,6 +1713,7 @@ async def test_create_work_item_without_user_input_missing_jira_account_id(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(CommandHandler, 'projects')
 @patch.object(CommandHandler, 'get_create_metadata')
@@ -1705,8 +1722,11 @@ async def test_create_work_item_ask_user_input_project_key_no_projects_found(
     create_work_item_mock: AsyncMock,
     get_create_metadata_mock: AsyncMock,
     projects_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1732,6 +1752,7 @@ async def test_create_work_item_ask_user_input_project_key_no_projects_found(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(questionary.Question, 'ask_async')
 @patch.object(CommandHandler, 'projects')
@@ -1742,8 +1763,11 @@ async def test_create_work_item_ask_user_input_project_key_no_project_provided(
     get_create_metadata_mock: AsyncMock,
     projects_mock: AsyncMock,
     ask_async_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1771,6 +1795,7 @@ async def test_create_work_item_ask_user_input_project_key_no_project_provided(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(questionary.Question, 'ask_async')
 @patch.object(CommandHandler, 'projects')
@@ -1781,8 +1806,11 @@ async def test_create_work_item_ask_user_input_project_key_provided(
     get_create_metadata_mock: AsyncMock,
     projects_mock: AsyncMock,
     ask_async_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1816,6 +1844,7 @@ async def test_create_work_item_ask_user_input_project_key_provided(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(questionary.Question, 'ask_async')
 @patch.object(CommandHandler, 'work_item_types_by_project')
@@ -1826,8 +1855,11 @@ async def test_create_work_item_ask_user_input_item_type_no_type_provided(
     get_create_metadata_mock: AsyncMock,
     work_item_types_by_project_mock: AsyncMock,
     ask_async_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1854,6 +1886,7 @@ async def test_create_work_item_ask_user_input_item_type_no_type_provided(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(questionary.Question, 'ask_async')
 @patch.object(CommandHandler, 'work_item_types_by_project')
@@ -1864,8 +1897,11 @@ async def test_create_work_item_ask_user_input_item_type_provided(
     get_create_metadata_mock: AsyncMock,
     work_item_types_by_project_mock: AsyncMock,
     ask_async_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1898,6 +1934,7 @@ async def test_create_work_item_ask_user_input_item_type_provided(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(questionary.Question, 'ask_async')
 @patch.object(CommandHandler, 'projects')
@@ -1908,8 +1945,11 @@ async def test_create_work_item_ask_user_input_summary_provided(
     get_create_metadata_mock: AsyncMock,
     projects_mock: AsyncMock,
     ask_async_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1942,6 +1982,7 @@ async def test_create_work_item_ask_user_input_summary_provided(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(questionary.Question, 'ask_async')
 @patch.object(CommandHandler, 'get_create_metadata')
@@ -1950,8 +1991,11 @@ async def test_create_work_item_ask_user_required_parent_key(
     create_work_item_mock: AsyncMock,
     get_create_metadata_mock: AsyncMock,
     ask_async_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')
@@ -1985,6 +2029,7 @@ async def test_create_work_item_ask_user_required_parent_key(
 
 
 @pytest.mark.asyncio
+@patch('jiratui.commands.handler.ApplicationConfiguration')
 @patch.object(CommandHandler, 'jira_account_id', PropertyMock(return_value='12345'))
 @patch.object(questionary.Question, 'ask_async')
 @patch.object(CommandHandler, 'get_create_metadata')
@@ -1993,8 +2038,11 @@ async def test_create_work_item_parent_key_not_required(
     create_work_item_mock: AsyncMock,
     get_create_metadata_mock: AsyncMock,
     ask_async_mock: AsyncMock,
+    config_mock,
+    config_for_testing,
 ):
     # GIVEN
+    config_mock.return_value = config_for_testing
     handler = CommandHandler()
     create_work_item_mock.return_value = APIControllerResponse(
         result=JiraBaseIssue(id='1', key='WI-1')

--- a/uv.lock
+++ b/uv.lock
@@ -732,6 +732,7 @@ dependencies = [
     { name = "pydantic-settings", extra = ["yaml"] },
     { name = "python-dateutil" },
     { name = "python-json-logger" },
+    { name = "questionary" },
     { name = "textual", extra = ["syntax"] },
     { name = "textual-autocomplete" },
     { name = "textual-image" },
@@ -776,6 +777,7 @@ requires-dist = [
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.14.2,<3.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-json-logger", specifier = ">=4.1.0,<5.0.0" },
+    { name = "questionary", specifier = ">=2.1.1" },
     { name = "textual", extras = ["syntax"], specifier = ">=8.2.7,<9.0.0" },
     { name = "textual-autocomplete", specifier = ">=4.0.6" },
     { name = "textual-image", specifier = ">=0.13.2,<0.14.0" },
@@ -1312,6 +1314,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1632,6 +1646,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -2379,6 +2405,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The CLI offers a basic command to create new work items.

> [!IMPORTANT]
>  The CLI application only supports creating work items that require only the following fields:
>      - issuetype
>      - project
>      - reporter
>      - summary
>      - parent (for creating subtasks)
>  If creating the work item requires any other field then the user needs to use the UI application.


The command to create a new work item is

```shell
jiratui issues new
```

You can use this command without arguments. In this case the command will ask you for the required input.

Example:

```shell
jiratui issues new
? Please specify the Jira project/space to which the work item belongs. (Use arrow keys)
  > Project 1
  Project 2
? Please specify the type of work item to create. (Use arrow keys)
  > Task
  Bug
? Provide the summary of the work item: Test summary
Work item with key WI-123 created successfully
View it with: jiratui issues search -k WI-123
```

You can also pass some of the required arguments. This includes:

- the project's key (`-p 123`)
- the id of the type of item (`-t 10001`)
- the summary (`-s 'Some text'`)

```shell
jiratui issues new -p 123 -t 1001 -s 'Implement...'
```

> [!TIP]
> You can cancel the command at any time with `ctrl+c`.
