### PR TITLE
Fix menus where the accent border was missing

### DIFF
--- a/src/jiratui/css/jt.tcss
+++ b/src/jiratui/css/jt.tcss
@@ -282,6 +282,10 @@ CustomTitle > Rule.-horizontal {
 .dropdown {
     border: round $primary-lighten-3;
     padding: 0 1;
+    /* focus-within: while the overlay is open the child SelectOverlay holds the focus */
+    &:focus-within {
+        border: round $accent-lighten-3;
+    }
 }
 
 .input-checkbox {
@@ -583,6 +587,9 @@ IssueLinkTypeSelector {
     width: auto;
     border: round $accent;
     padding: 0 1;
+    &:focus-within {
+        border: round $accent-lighten-3;
+    }
 }
 
 LinkedWorkItemInputWidget {
@@ -606,11 +613,17 @@ LinkedWorkItemInputWidget {
 WorkItemProjectSelectionField {
     border: round $accent;
     padding: 0 1;
+    &:focus-within {
+        border: round $accent-lighten-3;
+    }
 }
 
 WorkItemTypeSelectionField {
     border: round $accent;
     padding: 0 1;
+    &:focus-within {
+        border: round $accent-lighten-3;
+    }
 }
 
 .create-work-item-multi-user-picker {
@@ -632,6 +645,9 @@ WorkItemTypeSelectionField {
 .create-work-item-user-picker {
     border: round $primary-lighten-3;
     padding: 0 1;
+    &:focus-within {
+        border: round $accent-lighten-3;
+    }
 }
 
 .create-work-item-generic-input-field {
@@ -662,6 +678,9 @@ WorkItemTypeSelectionField {
     &.required {
         border: round $accent;
     }
+    &:focus-within {
+        border: round $accent-lighten-3;
+    }
 }
 
 .update-work-item-generic-selector {
@@ -674,6 +693,9 @@ WorkItemTypeSelectionField {
     background: $background;
     &.required {
         border: round $accent;
+    }
+    &:focus-within {
+        border: round $accent-lighten-3;
     }
 }
 
@@ -1196,6 +1218,9 @@ GitBranchNameInput {
 GitRepositorySelectionWidget {
     border: round $accent;
     padding: 0 1;
+    &:focus-within {
+        border: round $accent-lighten-3;
+    }
 }
 
 /* Screen for logging work */


### PR DESCRIPTION
# Highlight focused dropdown sections
Fix the visual focus state for dropdown selections in the Jira TUI.

When a dropdown menu is opened, the menu overlay receives focus. The surrounding selection box therefore did not appear highlighted, making it unclear which field was active.

This change adds `:focus-within` styling to the relevant select and dropdown widgets so the containing box remains highlighted while the menu is open.


### Before
<img width="1896" height="166" alt="image" src="https://github.com/user-attachments/assets/65290a94-3335-4d80-bc4c-899eaae8c9bf" />
<img width="397" height="86" alt="image" src="https://github.com/user-attachments/assets/13efc494-535e-4a52-8203-90b57931309f" />



### After

<img width="1881" height="136" alt="image" src="https://github.com/user-attachments/assets/e1858d33-5dda-4c28-a56a-11b5b4d5db5e" />
<img width="380" height="98" alt="image" src="https://github.com/user-attachments/assets/b359ae7f-29b3-4421-94d2-f8322c8ff790" />




> Made sure to run  `uv run --group test python -m pytest src/jiratui/tests/test_app.py -q` as well :D

