### PR TITLE
fix: render Jira Data Center HTML descriptions as text

### DIFF
--- a/src/jiratui/utils/html.py
+++ b/src/jiratui/utils/html.py
@@ -1,0 +1,96 @@
+"""Utilities for presenting HTML returned by Jira Data Center as readable text."""
+
+from html.parser import HTMLParser
+import re
+
+_HTML_TAG_RE = re.compile(
+    r'</?(?:a|address|article|aside|b|blockquote|br|code|div|em|footer|h[1-6]|header|i|li|ol|p|pre|'
+    r'script|section|span|strong|style|table|tbody|td|th|thead|tr|ul)\b[^>]*>',
+    re.IGNORECASE,
+)
+
+
+class _HTMLToTextParser(HTMLParser):
+    """Convert common Jira-rendered HTML into terminal-friendly plain text."""
+
+    _BLOCK_TAGS = {
+        'address',
+        'article',
+        'aside',
+        'blockquote',
+        'div',
+        'footer',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'header',
+        'p',
+        'pre',
+        'section',
+        'table',
+        'tr',
+        'ul',
+        'ol',
+    }
+    _IGNORED_TAGS = {'script', 'style'}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._ignored_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in self._IGNORED_TAGS:
+            self._ignored_depth += 1
+            return
+        if self._ignored_depth:
+            return
+        if tag == 'br':
+            self._parts.append('\n')
+        elif tag == 'li':
+            self._ensure_newline()
+            self._parts.append('- ')
+        elif tag == 'td' or tag == 'th':
+            if self._parts and not self._parts[-1].endswith(('\n', '\t')):
+                self._parts.append('\t')
+        elif tag in self._BLOCK_TAGS:
+            self._ensure_newline()
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in self._IGNORED_TAGS:
+            if self._ignored_depth:
+                self._ignored_depth -= 1
+            return
+        if self._ignored_depth:
+            return
+        if tag in self._BLOCK_TAGS or tag == 'li':
+            self._ensure_newline()
+
+    def handle_data(self, data: str) -> None:
+        if not self._ignored_depth:
+            self._parts.append(data)
+
+    def _ensure_newline(self) -> None:
+        if self._parts and not self._parts[-1].endswith('\n'):
+            self._parts.append('\n')
+
+    def text(self) -> str:
+        text = ''.join(self._parts)
+        text = re.sub(r'[ \t]+\n', '\n', text)
+        text = re.sub(r'\n{3,}', '\n\n', text)
+        return text.strip()
+
+
+def html_to_text_if_needed(content: str) -> str:
+    """Return readable text for HTML strings while leaving ordinary text unchanged."""
+
+    if not _HTML_TAG_RE.search(content):
+        return content
+
+    parser = _HTMLToTextParser()
+    parser.feed(content)
+    parser.close()
+    return parser.text()

--- a/src/jiratui/utils/tests/test_html.py
+++ b/src/jiratui/utils/tests/test_html.py
@@ -1,0 +1,19 @@
+import pytest
+
+from jiratui.utils.html import html_to_text_if_needed
+
+
+@pytest.mark.parametrize(
+    ('content', 'expected'),
+    [
+        ('Plain Jira text', 'Plain Jira text'),
+        ('2 < 3 and 5 > 4', '2 < 3 and 5 > 4'),
+        ('Use List<T> for this value', 'Use List<T> for this value'),
+        ('<p>Hello <strong>world</strong></p>', 'Hello world'),
+        ('<p>First<br>second</p><p>Third</p>', 'First\nsecond\nThird'),
+        ('<ul><li>One</li><li>Two &amp; three</li></ul>', '- One\n- Two & three'),
+        ('<p>Visible</p><script>alert(1)</script><style>.x { color: red; }</style>', 'Visible'),
+    ],
+)
+def test_html_to_text_if_needed(content: str, expected: str):
+    assert html_to_text_if_needed(content) == expected

--- a/src/jiratui/widgets/commons/factory_utils.py
+++ b/src/jiratui/widgets/commons/factory_utils.py
@@ -17,6 +17,7 @@ from textual.widget import Widget
 from textual.widgets import Select
 
 from jiratui.config import CONFIGURATION
+from jiratui.utils.html import html_to_text_if_needed
 from jiratui.widgets.commons import FieldMode
 from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
 from jiratui.widgets.commons.widgets import (
@@ -741,7 +742,7 @@ def build_read_only_rich_text_widget(
         jira_field_key=jira_field_key,
         title=field_name,
         required=required,
-        original_value=content or '',  # type:ignore[arg-type]
+        original_value=html_to_text_if_needed(content) if isinstance(content, str) else '',
     )
 
 

--- a/src/jiratui/widgets/commons/tests/test_factory.py
+++ b/src/jiratui/widgets/commons/tests/test_factory.py
@@ -472,6 +472,23 @@ def test_build_read_only_rich_text_widget_without_adf_support_enabled(
     assert widget.border_subtitle == '(*)'
 
 
+@patch('jiratui.widgets.commons.factory_utils._adf_support_enabled')
+def test_build_read_only_rich_text_widget_converts_data_center_html(
+    adf_support_enabled_mock: Mock,
+):
+    # GIVEN
+    adf_support_enabled_mock.return_value = False
+    # WHEN
+    widget = build_read_only_rich_text_widget(
+        jira_field_key='description',
+        field_name='Description',
+        content='<p>Hello <strong>world</strong></p><ul><li>One</li><li>Two</li></ul>',
+    )
+    # THEN
+    assert isinstance(widget, ReadOnlyPlainTextTextAreaWidget)
+    assert widget.text_content == 'Hello world\n- One\n- Two'
+
+
 @pytest.mark.parametrize(
     'allowed_values,expected',
     [


### PR DESCRIPTION
Fixes #326.

Jira Data Center can return rich-text fields as rendered HTML. The non-ADF display path currently passes those strings directly to a read-only TextArea, so users see tags such as `<p>` and `<strong>`.

This change converts recognized Jira HTML to terminal-friendly plain text only in the read-only display path. Ordinary strings (including text such as `List<T>`) are left unchanged, and the existing ADF path is untouched. Script/style contents are ignored and common block/list tags retain readable line breaks.

Validation:
- `ruff check` on the modified files
- `ruff format --check` after formatting
- 10 focused tests covering plain text, HTML paragraphs/lists/entities, ignored script/style content, generic angle-bracket text, and the read-only widget factory
- `git diff --check`