### PR TITLE
JT-77: extract and display web links from text content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extract and display web links found in Markdown context. If links are found in the content then a collapsible section
 will appear in the Info tab's text panes (description, environment, etc.) so the use can open the desired
-links. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/346
+links. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/347
 
 ## [1.13.1] 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- Extract and display web links found in Markdown context. If links are found in the content then a collapsible section
+will appear in the Info tab's text panes (description, environment, etc.) so the use can open the desired
+links. By [@whyisdifficult](https://github.com/whyisdifficult) in https://github.com/whyisdifficult/jiratui/pull/346
+
 ## [1.13.1] 2026-08-28
 
 ### Added

--- a/src/jiratui/css/jt.tcss
+++ b/src/jiratui/css/jt.tcss
@@ -1446,3 +1446,21 @@ MultiSelectWidget {
 .time-tracking-container {
     height: auto;
 }
+
+WebLinksCollapsible {
+    width: 1fr;
+    height: auto;
+    border: round $secondary-lighten-3;
+    padding: 0 0;
+    background: transparent;
+    &:focus-within {
+        background-tint: $foreground 5%;
+    }
+    &.-collapsed > Contents {
+        display: none;
+    }
+    & > CollapsibleTitle {
+        text-style: italic;
+        color: $accent-lighten-1;
+    }
+}

--- a/src/jiratui/utils/adf.py
+++ b/src/jiratui/utils/adf.py
@@ -1,4 +1,7 @@
-from marklas import to_adf, to_md
+import re
+
+from marklas import Transformer, parse_md, to_adf, to_md
+from marklas.ast import Inline, LinkMark, Mark, Paragraph, Text
 
 
 def convert_markdown_to_adf(content: str) -> dict:
@@ -25,3 +28,67 @@ def convert_adf_to_markdown(content: dict) -> str:
     """
 
     return to_md(content)
+
+
+# the links extracted from a Markdown content
+links: list[dict] = []
+
+
+def extract_web_links_from_markdown(content: str) -> list[dict]:
+    """Extracts Web links from a Markdown string.
+
+    Args:
+        content: The Markdown string to extract Web Links from.
+
+    Returns:
+        A list of dictionaries with the links found in the text.
+
+    Examples:
+    links = extract_web_links_from_markdown('View link https://foo.bar and [this link](https://bar.foo)')
+    links
+    [
+        {
+            'title': 'https://foo.bar',
+            'url': 'https://foo.bar',
+        },
+        {
+            'title': 'this link',
+            'url': 'https://bar.foo',
+        }
+    ]
+    """
+
+    link_parser_transformer = Transformer()
+
+    @link_parser_transformer.register(Paragraph)
+    def _process_paragraph(node: Paragraph) -> Paragraph | None:
+        global links
+        raw_urls_regex = re.compile(
+            r'https?://[^\s\[\]()]+|ftp://[^\s\[\]()]+|(?:www\.)[^\s\[\]()]+|(?<![\(\[])(?<![a-zA-Z]\()(?:(?<!\()\b(?:[a-z]{2,}\.)+(com|org|net|edu|gov|io|co|uk)\b)',
+            re.MULTILINE,
+        )
+        c: Inline
+        m: Mark
+        for c in node.content:
+            if not isinstance(c, Text):
+                continue
+            link_text = c.text or ''
+            for m in c.marks:
+                if isinstance(m, LinkMark):
+                    links.append({'url': m.href, 'title': m.title or link_text})
+            # there may also be "raw" links in the text; i.e. w/o Markdown []() syntax. We need to extract these using a
+            # regex
+            if link_text:
+                for link in raw_urls_regex.finditer(link_text):
+                    if href := link.group():
+                        links.append({'url': href, 'title': href})
+        return node
+
+    if not content:
+        return []
+
+    global links
+    links = []
+    ast_doc = parse_md(content)
+    link_parser_transformer(ast_doc)
+    return links[:] or []

--- a/src/jiratui/widgets/comments/comments.py
+++ b/src/jiratui/widgets/comments/comments.py
@@ -21,7 +21,7 @@ from jiratui.utils.urls import build_external_url_for_comment
 from jiratui.widgets.comments.add import AddCommentScreen
 from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
 from jiratui.widgets.commons.factory_utils import build_read_only_rich_text_widget
-from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget
+from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget, WebLinksCollapsible
 from jiratui.widgets.screens.confirmation import ConfirmationScreen
 
 
@@ -273,6 +273,7 @@ class IssueCommentsWidget(Actionable, VerticalScroll, inherit_bindings=False):  
             )
             widget: ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
             for comment in comments_list:
+                web_links: list[Link] = []
                 if comment.rich_text_value_is_empty(comment.body):  # type:ignore[arg-type]
                     widget = Static('There is no "Comment" set.', classes='tip')
                 else:
@@ -282,6 +283,7 @@ class IssueCommentsWidget(Actionable, VerticalScroll, inherit_bindings=False):  
                         required=False,
                         content=comment.body,
                     )
+                    web_links = widget.extract_web_links()
 
                 url = (
                     build_external_url_for_comment(self._work_item_key, comment.id)
@@ -295,11 +297,22 @@ class IssueCommentsWidget(Actionable, VerticalScroll, inherit_bindings=False):  
                 )
                 hg.compose_add_child(Static(f' | Last Update: {comment.updated_on()}'))
 
+                collapsible_child_widgets: list[
+                    ReadOnlyADFMarkdownTextAreaWidget
+                    | ReadOnlyPlainTextTextAreaWidget
+                    | Static
+                    | WebLinksCollapsible
+                ] = [widget]
+                if web_links:
+                    collapsible_child_widgets = [
+                        WebLinksCollapsible(*web_links)
+                    ] + collapsible_child_widgets
+
                 elements.append(
                     CommentCollapsible(
                         hg,
                         Rule(classes='rule-horizontal-compact-70'),
-                        widget,
+                        *collapsible_child_widgets,
                         title=Text(comment.short_metadata()),
                         work_item_key=self._work_item_key,
                         comment_id=comment.id,

--- a/src/jiratui/widgets/commons/adf.py
+++ b/src/jiratui/widgets/commons/adf.py
@@ -119,10 +119,6 @@ class ReadOnlyADFMarkdownTextAreaWidget(Markdown):
         if value is None:
             return ''
 
-        # if it's already a string, return it
-        if isinstance(value, str):
-            return value if value.strip() else ''
-
         # if it's a dict (ADF format), convert to Markdown
         if isinstance(value, dict):
             try:
@@ -132,6 +128,10 @@ class ReadOnlyADFMarkdownTextAreaWidget(Markdown):
                 # Fallback to string representation if conversion fails
                 logger.warning(f'Failed to convert ADF to markdown: {e}')
                 return str(value)
+
+        # if it's already a string, return it
+        if isinstance(value, str):
+            return value if value.strip() else ''
 
         # fallback for any other type
         return str(value)

--- a/src/jiratui/widgets/commons/adf.py
+++ b/src/jiratui/widgets/commons/adf.py
@@ -6,11 +6,15 @@ import logging
 
 from textual.binding import Binding
 from textual.message import Message
-from textual.widgets import Markdown, TextArea
+from textual.widgets import Link, Markdown, TextArea
 
 from jiratui.actions.constants import SupportedActions
 from jiratui.actions.keys import get_application_key_bindings
-from jiratui.utils.adf import convert_adf_to_markdown, convert_markdown_to_adf
+from jiratui.utils.adf import (
+    convert_adf_to_markdown,
+    convert_markdown_to_adf,
+    extract_web_links_from_markdown,
+)
 from jiratui.utils.ui_actions import Actionable, UIAction
 from jiratui.widgets.commons import BaseFieldWidget, BaseUpdateFieldWidget, FieldMode
 
@@ -35,6 +39,8 @@ class ReadOnlyADFMarkdownTextAreaWidget(Markdown):
     - Automatic ADF to Markdown conversion on initialization
     - Rich text rendering (not editable Markdown)
     - Read-only display
+    - This widget provides a method to extract web links found in the text content being displayed. This is useful to
+     help the user navigate the links in the text; Markdown widgets do not support this.
 
     **Usage**:
 
@@ -144,6 +150,14 @@ class ReadOnlyADFMarkdownTextAreaWidget(Markdown):
     @property
     def field_title(self) -> str:
         return self.__title
+
+    def extract_web_links(self) -> list[Link]:
+        if not self.__markdown_text:
+            return []
+        web_links_in_text: list[dict] = extract_web_links_from_markdown(self.__markdown_text)
+        return [
+            Link(text=url.get('title', 'link'), url=url.get('url')) for url in web_links_in_text
+        ]
 
 
 class ADFMarkdownTextAreaWidget(Actionable, TextArea, BaseFieldWidget, BaseUpdateFieldWidget):

--- a/src/jiratui/widgets/commons/factory_utils.py
+++ b/src/jiratui/widgets/commons/factory_utils.py
@@ -679,7 +679,7 @@ def build_read_only_rich_text_widget(
     """A factory method that builds a widget for displaying the content of a textarea field in read-only mode.
 
     Some Jira issue's fields can contain long rich text. Jira stores these values as either ADF
-    (Atlassian Document Format), when using theJira CLoud Platform, or as plain text, when using the Jira DC Platform.
+    (Atlassian Document Format), when using theJira Cloud Platform, or as plain text, when using the Jira DC Platform.
 
     JiraTUI will display these fields as either a Markdown widget or a TextArea widget according to these rules:
 

--- a/src/jiratui/widgets/commons/widgets.py
+++ b/src/jiratui/widgets/commons/widgets.py
@@ -81,6 +81,7 @@ from textual.validation import Number, ValidationResult
 from textual.widgets import (
     Collapsible,
     Input,
+    Link,
     MaskedInput,
     Select,
     SelectionList,
@@ -93,6 +94,7 @@ from textual.widgets.selection_list import Selection
 
 from jiratui.actions.constants import SupportedActions
 from jiratui.actions.keys import get_application_key_bindings
+from jiratui.utils.adf import extract_web_links_from_markdown
 from jiratui.utils.ui_actions import Actionable, UIAction
 from jiratui.widgets.base import DateInput
 from jiratui.widgets.commons.base import (
@@ -1625,6 +1627,9 @@ class ReadOnlyPlainTextTextAreaWidget(TextArea):
 
     Use it in the Info tab or to display comment's content or to display fields in the read-only work item details
     screen.
+
+    This widget provides a method to extract web links found in the text content being displayed. This is useful to help
+    the user navigate the links in the text; Markdown widgets do not support this.
     """
 
     def __init__(
@@ -1684,6 +1689,14 @@ class ReadOnlyPlainTextTextAreaWidget(TextArea):
     @property
     def field_title(self) -> str:
         return self.__title
+
+    def extract_web_links(self) -> list[Link]:
+        if not self.text:
+            return []
+        web_links_in_text: list[dict] = extract_web_links_from_markdown(self.text)
+        return [
+            Link(text=url.get('title', 'link'), url=url.get('url')) for url in web_links_in_text
+        ]
 
 
 class EmptyTextAreaStaticWidget(Static):
@@ -2386,7 +2399,11 @@ class ActionableTabbedContent(Actionable, TabbedContent, inherit_bindings=False)
 
 
 class WebLinksCollapsible(Collapsible):
-    """A Collapsible that contains Link widgets."""
+    """A Collapsible to display web links.
+
+    This is useful for displaying links found in text content, e.g. comments, description, and other textarea (custom)
+    fields.
+    """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, title='Links in the text', **kwargs)
+        super().__init__(*args, title='View links found in the text', **kwargs)

--- a/src/jiratui/widgets/commons/widgets.py
+++ b/src/jiratui/widgets/commons/widgets.py
@@ -79,6 +79,7 @@ from textual.events import Key
 from textual.message import Message
 from textual.validation import Number, ValidationResult
 from textual.widgets import (
+    Collapsible,
     Input,
     MaskedInput,
     Select,
@@ -2382,3 +2383,10 @@ class ActionableTabbedContent(Actionable, TabbedContent, inherit_bindings=False)
         tabs = self.query_one(Tabs)
         if tabs.has_focus:
             tabs.action_previous_tab()
+
+
+class WebLinksCollapsible(Collapsible):
+    """A Collapsible that contains Link widgets."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, title='Links in the text', **kwargs)

--- a/src/jiratui/widgets/screens/tests/test_work_item_quick_view.py
+++ b/src/jiratui/widgets/screens/tests/test_work_item_quick_view.py
@@ -1,10 +1,11 @@
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest
+from textual.widgets import Link
 
 from jiratui.api_controller.controller import APIController, APIControllerResponse
 from jiratui.models import JiraIssue, JiraIssueSearchResponse
-from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget
+from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget, WebLinksCollapsible
 from jiratui.widgets.screens.work_item_quick_view import QuickViewDetails, WorkItemQuickViewScreen
 
 
@@ -400,6 +401,71 @@ async def test_mount_with_issue_metadata_single_tab(
         table = screen.query_one(QuickViewDetails)
         assert table.row_count == 13
         assert screen.tabbed_content.tab_count == 1
+
+
+@patch.object(JiraIssue, 'rich_text_value_is_empty')
+@patch.object(APIController, 'get_issue')
+@pytest.mark.asyncio
+async def test_mount_with_issue_metadata_single_tab_with_web_links_in_content(
+    get_issue_mock: AsyncMock,
+    rich_text_value_is_empty_mock: Mock,
+    mock_configuration,
+    jira_issues,
+    app,
+):
+    # GIVEN
+    rich_text_value_is_empty_mock.return_value = False
+    issue = jira_issues[0]
+    issue.edit_meta = {
+        'fields': {
+            'description': {
+                'required': False,
+                'schema': {
+                    'type': 'array',
+                    'items': 'option',
+                    'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:textarea',
+                    'customId': 10021,
+                },
+                'name': 'Flagged',
+                'key': 'description',
+                'operations': ['add', 'set', 'remove'],
+                'allowedValues': [{'value': 'Impediment', 'id': '10019'}],
+            },
+        }
+    }
+    issue.description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [
+            {
+                'type': 'paragraph',
+                'content': [{'type': 'text', 'text': 'Goodbye world! https://foo.bar'}],
+            }
+        ],
+    }
+    get_issue_mock.return_value = APIControllerResponse(
+        result=JiraIssueSearchResponse(issues=[issue])
+    )
+    mock_configuration.jira_base_url = 'http://foo.bar'
+    async with app.run_test() as pilot:
+        # WHEN
+        screen = WorkItemQuickViewScreen('WI-1')
+        await app.push_screen(screen)
+        await pilot.pause()
+        # THEN
+        get_issue_mock.assert_called_once_with(issue_id_or_key='WI-1')
+        rich_text_value_is_empty_mock.assert_has_calls(
+            [
+                call(issue.description),
+            ]
+        )
+        table = screen.query_one(QuickViewDetails)
+        assert table.row_count == 13
+        assert screen.tabbed_content.tab_count == 1
+        c = screen.tab_pane_description.query_one(WebLinksCollapsible)
+        link = c.query_one(Link)
+        assert link.text == 'https://foo.bar'
+        assert link.url == 'https://foo.bar'
 
 
 @patch('jiratui.widgets.screens.work_item_quick_view.build_read_only_rich_text_widget')

--- a/src/jiratui/widgets/screens/work_item_quick_view.py
+++ b/src/jiratui/widgets/screens/work_item_quick_view.py
@@ -8,12 +8,13 @@ from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.message import Message
 from textual.screen import ModalScreen
-from textual.widgets import DataTable, Footer, Rule, Static, TabPane
+from textual.widgets import DataTable, Footer, Link, Rule, Static, TabPane
 
 from jiratui.actions.constants import SupportedActions
 from jiratui.actions.keys import get_application_key_bindings
 from jiratui.api_controller.controller import APIControllerResponse
 from jiratui.models import JiraWorkItemFields
+from jiratui.utils.adf import extract_web_links_from_markdown
 from jiratui.utils.styling import (
     get_style_for_work_item_priority,
     get_style_for_work_item_status,
@@ -27,7 +28,11 @@ from jiratui.widgets.commons.factory_utils import (
     FieldMetadata,
     build_read_only_rich_text_widget,
 )
-from jiratui.widgets.commons.widgets import ActionableTabbedContent, ReadOnlyPlainTextTextAreaWidget
+from jiratui.widgets.commons.widgets import (
+    ActionableTabbedContent,
+    ReadOnlyPlainTextTextAreaWidget,
+    WebLinksCollapsible,
+)
 
 
 class QuickViewDetails(Actionable, DataTable, inherit_bindings=False):  # type:ignore[call-arg]
@@ -79,7 +84,8 @@ class QuickViewDetails(Actionable, DataTable, inherit_bindings=False):  # type:i
             super().__init__()
             self.work_item_key = work_item_key
 
-    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+    @on(DataTable.RowSelected)
+    def _request_searching_selected_item(self, event: DataTable.RowSelected) -> None:
         """Posts the message
         [WorkItemSelected](#jiratui.widgets.screens.work_item_quick_view.QuickViewDetails.WorkItemSelected) to ask the
         caller to search and load the work item displayed in the row.
@@ -184,6 +190,7 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
             )
             self.notify(f'Unable to retrieve the work item with key: {self._work_item_key}')
         elif response.result and (issues := response.result.issues):
+            web_links: list[Link] = []
             issue = issues[0]
             color_style_priority = get_style_for_work_item_priority(issue.priority_name)
             color_style_status = get_style_for_work_item_status(issue.status.name)
@@ -258,7 +265,7 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                 ]
             )
 
-            # set the content of the description tab
+            # set the content of the description tab/pane
             widget: ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static
             if issue.rich_text_value_is_empty(issue.description):
                 widget = Static('There is no Description set.', classes='tip')
@@ -269,6 +276,17 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                     required=False,
                     content=issue.description,
                 )
+                if widget.text_content:
+                    web_links_in_text: list[dict] = extract_web_links_from_markdown(
+                        widget.text_content
+                    )
+                    web_links = [
+                        Link(text=url.get('title', 'link'), url=url.get('url'))
+                        for url in web_links_in_text
+                    ]
+
+            if web_links:
+                await self.tab_pane_description.mount(WebLinksCollapsible(*web_links))
             await self.tab_pane_description.mount(widget)
 
             # display all the editable custom fields with whose type is textarea, i.e. those that support rich text
@@ -294,6 +312,7 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                         and metadata.key.lower() == JiraWorkItemFields.ENVIRONMENT.value
                     ):
                         field_name = metadata.name or metadata.key.replace('_', ' ').title()
+                        web_links = []
 
                         if metadata.key.lower() == JiraWorkItemFields.ENVIRONMENT.value:
                             if issue.rich_text_value_is_empty(issue.environment):
@@ -308,6 +327,14 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                                     required=metadata.required,
                                     content=issue.environment,
                                 )
+                                if widget.text_content:
+                                    web_links_in_text = extract_web_links_from_markdown(
+                                        widget.text_content
+                                    )
+                                    web_links = [
+                                        Link(text=url.get('title', 'link'), url=url.get('url'))
+                                        for url in web_links_in_text
+                                    ]
                         else:
                             # get the value of the field
                             field_value = issue.get_custom_field_value(field_id)
@@ -323,11 +350,25 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                                     required=metadata.required,
                                     content=field_value,
                                 )
+                                if widget.text_content:
+                                    web_links_in_text = extract_web_links_from_markdown(
+                                        widget.text_content
+                                    )
+                                    web_links = [
+                                        Link(text=url.get('title', 'link'), url=url.get('url'))
+                                        for url in web_links_in_text
+                                    ]
+
+                        pane_child_widgets = [widget]
+                        if web_links:
+                            pane_child_widgets = [
+                                WebLinksCollapsible(*web_links)
+                            ] + pane_child_widgets
 
                         await tabbed.add_pane(
                             TabPane(
                                 metadata.name,
-                                widget,
+                                *pane_child_widgets,
                                 id=f'tab-{field_id}',
                                 classes='summary-description-container',
                             )

--- a/src/jiratui/widgets/screens/work_item_quick_view.py
+++ b/src/jiratui/widgets/screens/work_item_quick_view.py
@@ -359,16 +359,19 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                                         for url in web_links_in_text
                                     ]
 
-                        pane_child_widgets = [widget]
+                        pane_widgets: list[
+                            ReadOnlyADFMarkdownTextAreaWidget
+                            | ReadOnlyPlainTextTextAreaWidget
+                            | Static
+                            | WebLinksCollapsible
+                        ] = [widget]
                         if web_links:
-                            pane_child_widgets = [
-                                WebLinksCollapsible(*web_links)
-                            ] + pane_child_widgets
+                            pane_widgets = [WebLinksCollapsible(*web_links)] + pane_widgets
 
                         await tabbed.add_pane(
                             TabPane(
                                 metadata.name,
-                                *pane_child_widgets,
+                                *pane_widgets,
                                 id=f'tab-{field_id}',
                                 classes='summary-description-container',
                             )

--- a/src/jiratui/widgets/screens/work_item_quick_view.py
+++ b/src/jiratui/widgets/screens/work_item_quick_view.py
@@ -14,7 +14,6 @@ from jiratui.actions.constants import SupportedActions
 from jiratui.actions.keys import get_application_key_bindings
 from jiratui.api_controller.controller import APIControllerResponse
 from jiratui.models import JiraWorkItemFields
-from jiratui.utils.adf import extract_web_links_from_markdown
 from jiratui.utils.styling import (
     get_style_for_work_item_priority,
     get_style_for_work_item_status,
@@ -276,14 +275,7 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                     required=False,
                     content=issue.description,
                 )
-                if widget.text_content:
-                    web_links_in_text: list[dict] = extract_web_links_from_markdown(
-                        widget.text_content
-                    )
-                    web_links = [
-                        Link(text=url.get('title', 'link'), url=url.get('url'))
-                        for url in web_links_in_text
-                    ]
+                web_links = widget.extract_web_links()
 
             if web_links:
                 await self.tab_pane_description.mount(WebLinksCollapsible(*web_links))
@@ -327,14 +319,7 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                                     required=metadata.required,
                                     content=issue.environment,
                                 )
-                                if widget.text_content:
-                                    web_links_in_text = extract_web_links_from_markdown(
-                                        widget.text_content
-                                    )
-                                    web_links = [
-                                        Link(text=url.get('title', 'link'), url=url.get('url'))
-                                        for url in web_links_in_text
-                                    ]
+                                web_links = widget.extract_web_links()
                         else:
                             # get the value of the field
                             field_value = issue.get_custom_field_value(field_id)
@@ -350,14 +335,7 @@ class WorkItemQuickViewScreen(Actionable, ModalScreen[str]):
                                     required=metadata.required,
                                     content=field_value,
                                 )
-                                if widget.text_content:
-                                    web_links_in_text = extract_web_links_from_markdown(
-                                        widget.text_content
-                                    )
-                                    web_links = [
-                                        Link(text=url.get('title', 'link'), url=url.get('url'))
-                                        for url in web_links_in_text
-                                    ]
+                                web_links = widget.extract_web_links()
 
                         pane_widgets: list[
                             ReadOnlyADFMarkdownTextAreaWidget

--- a/src/jiratui/widgets/work_item_info/info.py
+++ b/src/jiratui/widgets/work_item_info/info.py
@@ -20,7 +20,6 @@ from jiratui.api_controller.controller import APIControllerResponse
 from jiratui.config import CONFIGURATION
 from jiratui.exceptions import UpdateWorkItemException, ValidationError
 from jiratui.models import JiraIssue, JiraWorkItemFields
-from jiratui.utils.adf import extract_web_links_from_markdown
 from jiratui.widgets.commons import CustomFieldType
 from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
 from jiratui.widgets.commons.factory_utils import (
@@ -247,14 +246,7 @@ class WorkItemInfoContainer(Vertical):
                         required=field_metadata.get('required', False),
                         content=work_item.description,
                     )
-                    if widget.text_content:
-                        web_links_in_text: list[dict] = extract_web_links_from_markdown(
-                            widget.text_content
-                        )
-                        web_links = [
-                            Link(text=url.get('title', 'link'), url=url.get('url'))
-                            for url in web_links_in_text
-                        ]
+                    web_links = widget.extract_web_links()
 
                 pane = TextAreaTabPane(title='Description', widget_id='pane-description')
                 await self.info_tabbed_content.add_pane(pane)
@@ -322,14 +314,7 @@ class WorkItemInfoContainer(Vertical):
                         pane_title = widget.name
                     else:
                         pane_title = widget.field_title
-                        if widget.text_content:
-                            web_links_in_text: list[dict] = extract_web_links_from_markdown(
-                                widget.text_content
-                            )
-                            web_links = [
-                                Link(text=url.get('title', 'link'), url=url.get('url'))
-                                for url in web_links_in_text
-                            ]
+                        web_links = widget.extract_web_links()
 
                     pane = TextAreaTabPane(
                         title=pane_title or '', widget_id=f'pane-{widget.jira_field_key}'

--- a/src/jiratui/widgets/work_item_info/info.py
+++ b/src/jiratui/widgets/work_item_info/info.py
@@ -10,6 +10,7 @@ from textual.containers import Center, Vertical, VerticalGroup, VerticalScroll
 from textual.message import Message
 from textual.reactive import Reactive, reactive
 from textual.widgets import (
+    Link,
     LoadingIndicator,
     Rule,
     Static,
@@ -19,6 +20,7 @@ from jiratui.api_controller.controller import APIControllerResponse
 from jiratui.config import CONFIGURATION
 from jiratui.exceptions import UpdateWorkItemException, ValidationError
 from jiratui.models import JiraIssue, JiraWorkItemFields
+from jiratui.utils.adf import extract_web_links_from_markdown
 from jiratui.widgets.commons import CustomFieldType
 from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
 from jiratui.widgets.commons.factory_utils import (
@@ -28,6 +30,7 @@ from jiratui.widgets.commons.factory_utils import (
 from jiratui.widgets.commons.widgets import (
     EmptyTextAreaStaticWidget,
     ReadOnlyPlainTextTextAreaWidget,
+    WebLinksCollapsible,
 )
 from jiratui.widgets.work_item_info.screens import DisplayTextContentScreen, EditTextContentScreen
 from jiratui.widgets.work_item_info.tabs import InfoTabbedContent, TextAreaTabPane
@@ -97,8 +100,8 @@ class WorkItemInfoContainer(Vertical):
 
     @on(InfoTabbedContent.DisplayContent)
     def _display_content(self, event: InfoTabbedContent.DisplayContent) -> None:
-        self.app.push_screen(DisplayTextContentScreen(event.content, event.title))
         event.stop()
+        self.app.push_screen(DisplayTextContentScreen(event.content, event.title))
 
     def _handle_edit_result(self, data: dict | None) -> None:
         """Receives the result from the built-in editor and schedules the API update."""
@@ -220,6 +223,7 @@ class WorkItemInfoContainer(Vertical):
 
         if issue_edit_metadata := work_item.get_edit_metadata():
             if field_metadata := issue_edit_metadata.get(JiraWorkItemFields.DESCRIPTION.value, {}):
+                web_links: list[Link] = []
                 field_name = field_metadata.get('name') or field_metadata.get('key', 'Description')
                 field_name = field_name.title()
                 widget: (
@@ -243,8 +247,19 @@ class WorkItemInfoContainer(Vertical):
                         required=field_metadata.get('required', False),
                         content=work_item.description,
                     )
+                    if widget.text_content:
+                        web_links_in_text: list[dict] = extract_web_links_from_markdown(
+                            widget.text_content
+                        )
+                        web_links = [
+                            Link(text=url.get('title', 'link'), url=url.get('url'))
+                            for url in web_links_in_text
+                        ]
+
                 pane = TextAreaTabPane(title='Description', widget_id='pane-description')
                 await self.info_tabbed_content.add_pane(pane)
+                if web_links:
+                    await pane.mount(WebLinksCollapsible(*web_links))
                 await pane.mount(widget)
 
     async def _refresh_tabs_and_set_work_item(self, work_item: JiraIssue | None):
@@ -302,14 +317,26 @@ class WorkItemInfoContainer(Vertical):
                     | EmptyTextAreaStaticWidget
                 ] = self._build_textarea_widgets(work_item)
                 for widget in widgets:
+                    web_links: list[Link] = []
                     if isinstance(widget, EmptyTextAreaStaticWidget):
                         pane_title = widget.name
                     else:
                         pane_title = widget.field_title
+                        if widget.text_content:
+                            web_links_in_text: list[dict] = extract_web_links_from_markdown(
+                                widget.text_content
+                            )
+                            web_links = [
+                                Link(text=url.get('title', 'link'), url=url.get('url'))
+                                for url in web_links_in_text
+                            ]
 
-                    pane_id = f'pane-{widget.jira_field_key}'
-                    pane = TextAreaTabPane(title=pane_title, widget_id=pane_id)
+                    pane = TextAreaTabPane(
+                        title=pane_title or '', widget_id=f'pane-{widget.jira_field_key}'
+                    )
                     await self.info_tabbed_content.add_pane(pane)
+                    if web_links:
+                        await pane.mount(WebLinksCollapsible(*web_links))
                     await pane.mount(widget)
 
     def _build_textarea_widgets(

--- a/src/jiratui/widgets/work_item_info/tabs.py
+++ b/src/jiratui/widgets/work_item_info/tabs.py
@@ -1,18 +1,25 @@
 from textual.binding import Binding
 from textual.css.query import NoMatches
 from textual.message import Message
-from textual.widgets import Static, TabbedContent, TabPane, Tabs
+from textual.widgets import TabbedContent, TabPane, Tabs
 
 from jiratui.actions.constants import SupportedActions
 from jiratui.actions.keys import get_application_key_bindings
 from jiratui.utils.ui_actions import Actionable, UIAction
 from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
-from jiratui.widgets.commons.widgets import ReadOnlyPlainTextTextAreaWidget
+from jiratui.widgets.commons.widgets import (
+    EmptyTextAreaStaticWidget,
+    ReadOnlyPlainTextTextAreaWidget,
+)
 
 
 class InfoTabbedContent(Actionable, TabbedContent, inherit_bindings=False):  # type:ignore[call-arg]
     """Custom TabbedContent with key bindings for editing, viewing and copying the content of the currently active
-    pane/tab."""
+    pane/tab.
+
+    This widget expects a single `TextAreaTabPane` that contains the text of a Jira's textarea (custom) field,
+    including the description and environment fields.
+    """
 
     ACTIONS: list[UIAction] = []
     # set up the key-bindings based on the configuration selected by the user
@@ -77,7 +84,12 @@ class InfoTabbedContent(Actionable, TabbedContent, inherit_bindings=False):  # t
 
     def _get_textarea_widget(
         self,
-    ) -> ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None:
+    ) -> (
+        ReadOnlyADFMarkdownTextAreaWidget
+        | ReadOnlyPlainTextTextAreaWidget
+        | EmptyTextAreaStaticWidget
+        | None
+    ):
         if (active_pane := self.active_pane) is None:
             return None
         try:
@@ -87,7 +99,7 @@ class InfoTabbedContent(Actionable, TabbedContent, inherit_bindings=False):  # t
                 return active_pane.query_one(ReadOnlyPlainTextTextAreaWidget)
             except NoMatches:
                 try:
-                    return active_pane.query_one(Static)
+                    return active_pane.query_one(EmptyTextAreaStaticWidget)
                 except NoMatches:
                     return None
 
@@ -96,10 +108,13 @@ class InfoTabbedContent(Actionable, TabbedContent, inherit_bindings=False):  # t
         widget."""
 
         widget: (
-            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+            ReadOnlyADFMarkdownTextAreaWidget
+            | ReadOnlyPlainTextTextAreaWidget
+            | EmptyTextAreaStaticWidget
+            | None
         ) = self._get_textarea_widget()
         if widget is not None:
-            if isinstance(widget, Static):
+            if isinstance(widget, EmptyTextAreaStaticWidget):
                 content_to_edit = ''
                 jira_field_key = widget.id
                 title = widget.name
@@ -114,10 +129,13 @@ class InfoTabbedContent(Actionable, TabbedContent, inherit_bindings=False):  # t
         pane's widget."""
 
         widget: (
-            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+            ReadOnlyADFMarkdownTextAreaWidget
+            | ReadOnlyPlainTextTextAreaWidget
+            | EmptyTextAreaStaticWidget
+            | None
         ) = self._get_textarea_widget()
         if widget is not None:
-            if isinstance(widget, Static):
+            if isinstance(widget, EmptyTextAreaStaticWidget):
                 key = self.key_bindings.get(SupportedActions.EDIT_CONTENT.value).get('keys', [])[0]
                 self.notify(f'The field {widget.name} has no content. Press "{key}" to edit it.')
             else:
@@ -127,10 +145,13 @@ class InfoTabbedContent(Actionable, TabbedContent, inherit_bindings=False):  # t
         """Copy to the clipboard the content of the field."""
 
         widget: (
-            ReadOnlyADFMarkdownTextAreaWidget | ReadOnlyPlainTextTextAreaWidget | Static | None
+            ReadOnlyADFMarkdownTextAreaWidget
+            | ReadOnlyPlainTextTextAreaWidget
+            | EmptyTextAreaStaticWidget
+            | None
         ) = self._get_textarea_widget()
         if widget is not None:
-            if isinstance(widget, Static):
+            if isinstance(widget, EmptyTextAreaStaticWidget):
                 key = self.key_bindings.get(SupportedActions.EDIT_CONTENT.value).get('keys', [])[0]
                 self.notify(f'The field {widget.name} has no content. Press "{key}" to edit it.')
             else:
@@ -139,8 +160,15 @@ class InfoTabbedContent(Actionable, TabbedContent, inherit_bindings=False):  # t
 
 
 class TextAreaTabPane(TabPane):
-    """A custom TabPane that contains either ReadOnlyADFMarkdownTextAreaWidget or ReadOnlyPlainTextTextAreaWidget as
-    its child."""
+    """A custom TabPane that contains the text content of a Jira's textarea (custom) field including the description
+    and environment fields.
+
+    This `TextAreaTabPane` widget expects 2 child widgets:
+
+    - an optional `WebLinksCollapsible` widget that contains the links found in the text content.
+    - an instance of `ReadOnlyADFMarkdownTextAreaWidget` or `ReadOnlyPlainTextTextAreaWidget` or
+    `EmptyTextAreaStaticWidget` that contains the actual text content of a Jira's textarea (custom) field.
+    """
 
     def __init__(self, title: str, widget_id: str, **kwargs):
         super().__init__(title=title, id=widget_id, **kwargs)

--- a/src/jiratui/widgets/work_item_info/tests/test_info.py
+++ b/src/jiratui/widgets/work_item_info/tests/test_info.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
-from textual.widgets import Rule, Static
+from textual.widgets import Link, Rule, Static
 
 from jiratui.api_controller.controller import APIController, APIControllerResponse
 from jiratui.app import JiraApp
@@ -9,6 +9,7 @@ from jiratui.exceptions import UpdateWorkItemException, ValidationError
 from jiratui.models import JiraIssue
 from jiratui.widgets.commons.adf import ReadOnlyADFMarkdownTextAreaWidget
 from jiratui.widgets.commons.factory_utils import build_read_only_rich_text_widget
+from jiratui.widgets.commons.widgets import WebLinksCollapsible
 from jiratui.widgets.work_item_info.info import (
     WorkItemInfoContainer,
 )
@@ -54,6 +55,60 @@ async def test_work_item_info_container_with_summary_description_only(
         assert tab_panes[0].children[0].border_title == 'Description'
         assert tab_panes[0].children[0].border_subtitle == '(*)'
         assert tab_panes[0].children[0].jira_field_key == 'description'
+
+
+@pytest.mark.asyncio
+async def test_work_item_info_container_with_summary_description_only_including_web_links(
+    jira_issues_with_custom_fields,
+    app,
+):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {
+            'description': {
+                'key': 'description',
+                'name': 'description',
+                'required': True,
+            },
+        }
+    }
+    jira_issues_with_custom_fields[0].description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [
+            {
+                'type': 'paragraph',
+                'content': [
+                    {'type': 'text', 'text': 'Hello world, try this link: https://foo.bar'}
+                ],
+            }
+        ],
+    }
+    async with app.run_test() as pilot:
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        await app.workers.wait_for_complete()
+        # WHEN
+        widget.issue = jira_issues_with_custom_fields[0]
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert widget.issue_summary_widget.content == 'abcd'
+        assert widget.query_one(Rule).visible is True
+        assert isinstance(widget.info_tabbed_content, InfoTabbedContent)
+        tab_panes = widget.info_tabbed_content.query(TextAreaTabPane)
+        assert len(tab_panes) == 1
+        assert isinstance(tab_panes[0], TextAreaTabPane)
+        assert tab_panes[0].id == 'pane-description'
+        widgets_in_tab_pane = tab_panes[0].children
+        assert len(widgets_in_tab_pane) == 2
+        assert isinstance(widgets_in_tab_pane[0], WebLinksCollapsible)
+        assert isinstance(widgets_in_tab_pane[1], ReadOnlyADFMarkdownTextAreaWidget)
+        assert widgets_in_tab_pane[1].border_title == 'Description'
+        assert widgets_in_tab_pane[1].border_subtitle == '(*)'
+        assert widgets_in_tab_pane[1].jira_field_key == 'description'
+        link = widgets_in_tab_pane[0].query_one(Link)
+        assert link.text == 'https://foo.bar'
+        assert link.url == 'https://foo.bar'
 
 
 @patch.object(
@@ -244,6 +299,89 @@ async def test_work_item_info_container_updating_additional_fields_enabled_with_
         assert tab_panes[0].children[0].border_title == 'Description'
         assert tab_panes[0].children[0].border_subtitle == '(*)'
         assert tab_panes[0].children[0].jira_field_key == 'description'
+
+
+@patch.object(
+    WorkItemInfoContainer, '_update_additional_fields_ignore_ids', PropertyMock(return_value=[])
+)
+@patch.object(
+    WorkItemInfoContainer, '_enable_updating_additional_fields', PropertyMock(return_value=True)
+)
+@pytest.mark.asyncio
+async def test_work_item_info_container_updating_additional_fields_enable_with_textarea_custom_type_with_web_links(
+    jira_issues_with_custom_fields,
+    app,
+):
+    # GIVEN
+    jira_issues_with_custom_fields[0].edit_meta = {
+        'fields': {
+            'description': {
+                'key': 'description',
+                'name': 'description',
+                'required': True,
+            },
+            'environment': {
+                'schema': {'custom': ''},
+                'key': 'environment',
+                'name': 'environment',
+                'required': True,
+            },
+            'field_a': {
+                'schema': {'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:textarea'},
+                'key': 'field_a',
+                'name': 'Field A',
+                'required': False,
+            },
+        }
+    }
+    jira_issues_with_custom_fields[0].description = {
+        'type': 'doc',
+        'version': 1,
+        'content': [{'type': 'paragraph', 'content': [{'type': 'text', 'text': 'Hello world!'}]}],
+    }
+    jira_issues_with_custom_fields[0].environment = {
+        'type': 'doc',
+        'version': 1,
+        'content': [
+            {
+                'type': 'paragraph',
+                'content': [{'type': 'text', 'text': 'Goodbye world! https://foo.bar'}],
+            }
+        ],
+    }
+    async with app.run_test() as pilot:
+        widget = WorkItemInfoContainer()
+        await app.screen.mount(widget)
+        await app.workers.wait_for_complete()
+        # WHEN
+        widget.issue = jira_issues_with_custom_fields[0]
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert widget.issue_summary_widget.content == 'abcd'
+        assert widget.query_one(Rule).visible is True
+        assert isinstance(widget.info_tabbed_content, InfoTabbedContent)
+        tab_panes = widget.info_tabbed_content.query(TextAreaTabPane)
+        assert len(tab_panes) == 3
+        assert isinstance(tab_panes[0], TextAreaTabPane)
+        assert isinstance(tab_panes[1], TextAreaTabPane)
+        assert isinstance(tab_panes[2], TextAreaTabPane)
+        assert tab_panes[0].id == 'pane-description'
+        assert tab_panes[1].id == 'pane-environment'
+        assert tab_panes[2].id == 'pane-field_a'
+        assert isinstance(tab_panes[0].children[0], ReadOnlyADFMarkdownTextAreaWidget)
+        assert isinstance(tab_panes[1].children[0], WebLinksCollapsible)
+        assert isinstance(tab_panes[1].children[1], ReadOnlyADFMarkdownTextAreaWidget)
+        assert isinstance(tab_panes[2].children[0], Static)
+        assert tab_panes[0].children[0].border_title == 'Description'
+        assert tab_panes[0].children[0].border_subtitle == '(*)'
+        assert tab_panes[0].children[0].jira_field_key == 'description'
+        assert tab_panes[1].children[1].border_title == 'environment'
+        assert tab_panes[1].children[1].border_subtitle == '(*)'
+        assert tab_panes[1].children[1].jira_field_key == 'environment'
+        assert tab_panes[2].children[0].id == 'field_a'
+        link = tab_panes[1].query_one(Link)
+        assert link.text == 'https://foo.bar'
+        assert link.url == 'https://foo.bar'
 
 
 @patch.object(


### PR DESCRIPTION
The info tab now displays an optional collapsible with a list of links extracted form the text content of a textarea field.

<img width="758" height="695" alt="Screenshot 2026-09-08 at 19 50 05" src="https://github.com/user-attachments/assets/326e17c2-89d2-48ae-b2ea-1a2726115cde" />
